### PR TITLE
CI: Shipyard config + pin (macOS-only)

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -1,0 +1,60 @@
+# Shipyard configuration for Spectr.
+#
+# Spectr is a single-person, macOS-first Pulp-based plugin. This config
+# keeps Shipyard as lightweight as a single-platform project needs: one
+# target (mac-local), no version-bump or skill-sync gates (Spectr has no
+# CLI or skills to enforce). Namespace dispatch is wired up for
+# `shipyard cloud run` / failover when/if a cloud path is preferred.
+#
+# To use this config:
+#   ./tools/install-shipyard.sh   # install pinned Shipyard binary
+#   shipyard doctor               # verify reachability + config sanity
+#   shipyard run                  # validate the current branch locally
+#   shipyard ship                 # PR + validate + merge on green
+
+[project]
+name      = "spectr"
+type      = "cmake"
+platforms = ["macos"]
+
+# ── Validation pipeline ────────────────────────────────────────────────────
+# Canonical stages only: configure, build, test. The SDK prefix path is
+# read from pulp.toml's sdk_path when running locally; CI-dispatched
+# lanes set CMAKE_PREFIX_PATH via the runner's env.
+
+[validation.default]
+stages    = ["configure", "build", "test"]
+configure = "cmake -S . -B build -DCMAKE_PREFIX_PATH=$HOME/.pulp/sdk-local/darwin-arm64/0.38.0 -DCMAKE_BUILD_TYPE=Debug"
+build     = "cmake --build build --parallel"
+test      = "ctest --test-dir build --output-on-failure"
+
+# ── Targets ────────────────────────────────────────────────────────────────
+# One target for now: the developer's macOS-arm64 laptop. If Spectr ever
+# grows Windows/Linux surface area (M10 format validation is the natural
+# trigger), add them here alongside.
+
+[targets.mac]
+backend  = "local"
+platform = "macos-arm64"
+
+# ── Cloud dispatch (Namespace) ─────────────────────────────────────────────
+# Enables `shipyard cloud run build <branch>` against Namespace-hosted
+# runners. Not strictly required for `shipyard ship` (which uses the
+# local mac target), but wired up so the option exists without a later
+# config change.
+
+[cloud]
+provider   = "namespace"
+workflow   = "build"
+repository = "danielraffel/spectr"
+
+# ── Merge gating ───────────────────────────────────────────────────────────
+# Ship blocks until the macOS target passes on the merge-candidate SHA.
+
+[merge]
+require_platforms = ["macos"]
+
+# ── Ship defaults ──────────────────────────────────────────────────────────
+
+[ship]
+base_branch = "main"

--- a/tools/install-shipyard.sh
+++ b/tools/install-shipyard.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# install-shipyard.sh — install the pinned Shipyard release declared
+# in tools/shipyard.toml.
+#
+# Delegates to Shipyard's official installer (install.sh) via
+# SHIPYARD_VERSION, which lands the binary at ~/.local/bin/shipyard.
+# This wrapper owns the version pin; Shipyard owns the download,
+# verification, and install mechanics. Picking up upstream installer
+# fixes is automatic — we only bump the pin.
+#
+# Installer source is pinned to the same Shipyard release as the
+# binary (`tags/<pinned-version>/install.sh`), so a given Spectr
+# commit always runs the same installer code.
+#
+# Usage:
+#   ./tools/install-shipyard.sh           # install pinned version
+#   ./tools/install-shipyard.sh --status  # show installed vs pinned
+#
+# Exit codes:
+#   0   success (or already installed and matching pin)
+#   1   user error (bad flag, missing tools)
+#   2   download / verification failure (propagated from installer)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PIN_FILE="$SCRIPT_DIR/shipyard.toml"
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+
+MODE=install
+for arg in "$@"; do
+    case "$arg" in
+        --status)  MODE=status ;;
+        -h|--help)
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument '$arg'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Read the pinned version from tools/shipyard.toml ────────────────────────
+
+if ! [ -f "$PIN_FILE" ]; then
+    echo "Error: pin file not found at $PIN_FILE" >&2
+    exit 1
+fi
+
+VERSION="$(sed -n '/^\[shipyard\]/,/^\[/p' "$PIN_FILE" \
+    | sed -n 's/^version[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p' \
+    | head -1)"
+
+if [ -z "$VERSION" ]; then
+    echo "Error: could not parse version from $PIN_FILE" >&2
+    exit 1
+fi
+
+UPSTREAM_INSTALLER="https://raw.githubusercontent.com/danielraffel/Shipyard/refs/tags/${VERSION}/install.sh"
+
+# ── Status mode: report and exit ────────────────────────────────────────────
+
+if [ "$MODE" = "status" ]; then
+    echo "Pinned (tools/shipyard.toml): $VERSION"
+    if command -v shipyard >/dev/null 2>&1; then
+        echo "shipyard on PATH:             $(command -v shipyard)"
+        if installed="$(shipyard --version 2>/dev/null)"; then
+            echo "Installed version:            $installed"
+        fi
+    else
+        echo "shipyard on PATH:             (not found — run ./tools/install-shipyard.sh)"
+    fi
+    exit 0
+fi
+
+# ── Queue-file truncation recovery ──────────────────────────────────────────
+# A crash between open(O_TRUNC) and write() in Shipyard can leave the
+# machine-global job queue at zero bytes. Any subsequent Shipyard
+# invocation then dies with JSONDecodeError. Re-running this installer
+# is the documented recovery path; defensively re-initialize if we see
+# the queue file truncated.
+repair_truncated_queue_file() {
+    local state_dir=""
+    case "$(uname -s)" in
+        Darwin)     state_dir="$HOME/Library/Application Support/shipyard" ;;
+        Linux)      state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/shipyard" ;;
+        MINGW*|MSYS*|CYGWIN*) state_dir="$HOME/AppData/Local/shipyard" ;;
+        *)          return 0 ;;
+    esac
+
+    local queue_file="$state_dir/queue/queue.json"
+    if [ -f "$queue_file" ] && [ ! -s "$queue_file" ]; then
+        echo "→ Shipyard queue file is empty — reinitializing"
+        mkdir -p "$(dirname "$queue_file")"
+        echo '{"jobs": []}' > "$queue_file"
+    fi
+}
+
+repair_truncated_queue_file
+
+# ── Delegate to upstream installer ──────────────────────────────────────────
+
+echo "→ Installing Shipyard $VERSION via upstream install.sh"
+echo "    source: $UPSTREAM_INSTALLER"
+
+SHIPYARD_VERSION="$VERSION" bash <(curl -fsSL "$UPSTREAM_INSTALLER")
+
+# ── Final report ────────────────────────────────────────────────────────────
+
+echo ""
+if command -v shipyard >/dev/null 2>&1; then
+    echo "✓ Shipyard $VERSION installed at $(command -v shipyard)."
+else
+    echo "Shipyard installed to ~/.local/bin/shipyard."
+    case ":$PATH:" in
+        *":$HOME/.local/bin:"*) ;;
+        *)
+            echo ""
+            echo "Add ~/.local/bin to your PATH to use shipyard from anywhere:"
+            echo ""
+            echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+            ;;
+    esac
+fi

--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -1,0 +1,42 @@
+# Spectr's pinned Shipyard release.
+#
+# Shipyard is the CI controller Spectr uses for PR validation and
+# merge gating. Spectr pins a specific Shipyard release here so every
+# checkout uses the same version.
+#
+# To install or upgrade:
+#   ./tools/install-shipyard.sh
+#
+# To check what's installed vs what's pinned:
+#   ./tools/install-shipyard.sh --status
+#
+# To bump the pin:
+#   1. Edit `version` below.
+#   2. Run `./tools/install-shipyard.sh` to download the new binary.
+#   3. Run `shipyard run` on a feature branch to verify.
+#   4. Open a PR with the version change + verification notes.
+#
+# This pin tracks pulp's pinned Shipyard version so the same ship
+# muscle memory works in both repos. See pulp/tools/shipyard.toml for
+# the cumulative release-note history.
+
+[shipyard]
+# v0.29.0 — tracks pulp's pin as of 2026-04-23. See pulp's
+# tools/shipyard.toml for the cumulative release-note history of each
+# version on the v0.2x line.
+version = "v0.29.0"
+
+# Public release source. The bootstrap script downloads from
+# https://github.com/{repo}/releases/download/{version}/{asset}
+repo = "danielraffel/Shipyard"
+
+# SHA-256 verification asset name (downloaded alongside the binary).
+checksums_asset = "checksums.sha256"
+
+# Per-platform binary asset names.
+[shipyard.assets]
+darwin-arm64  = "shipyard-macos-arm64"
+darwin-x64    = "shipyard-macos-x64"
+linux-arm64   = "shipyard-linux-arm64"
+linux-x64     = "shipyard-linux-x64"
+windows-x64   = "shipyard-windows-x64.exe"


### PR DESCRIPTION
Adds Spectr's first PR gate using Shipyard, patterned on pulp's setup but stripped to the minimum a single-platform single-developer project needs.

## What lands

- **`.shipyard/config.toml`** — one target (`mac`, local backend, `macos-arm64`), canonical `configure` / `build` / `test` stages. Runs against the pinned Pulp 0.38.0 SDK at `\$HOME/.pulp/sdk-local/darwin-arm64/0.38.0`. Namespace cloud dispatch is wired up under `[cloud]` for \`shipyard cloud run\` and as a failover path — not required for \`shipyard ship\`.
- **`tools/shipyard.toml`** — pins Shipyard **v0.29.0** (same version pulp pins on origin/main as of 2026-04-23).
- **`tools/install-shipyard.sh`** — thin wrapper around upstream's installer via \`SHIPYARD_VERSION\`. Same pattern pulp uses; lands the binary at `~/.local/bin/shipyard`.

## What's intentionally NOT included

- **No `validation.gates` stage.** Pulp's version-bump + skill-sync gates don't apply here — Spectr has no CLI to version and no skills to sync.
- **No Ubuntu / Windows targets.** Spectr builds only on macOS until **M10** (format validation across VST3/AU/CLAP), which is the natural trigger per the build plan.
- **No `.github/workflows/build.yml`** yet. \`shipyard ship\` validates on the local mac target; a Namespace-hosted GHA workflow for PR status checks can be added later if useful.

## Ship flow after merge

    ./tools/install-shipyard.sh
    shipyard doctor
    shipyard run           # validate current branch
    shipyard ship          # PR + validate + merge on green

## Verification

\`shipyard doctor\` on this branch:

    ✓ git / ssh / shipyard-on-path / daemon-version
    ✓ gh / nsc
    ✗ RELEASE_BOT_TOKEN missing    # only required for the release pipeline, not PRs
    Overall: ready

## Follow-ups

- Revisit \`validation.gates\` if Spectr grows a CLI or skill set worth enforcing.
- Add Ubuntu + Windows targets + a GHA status-check workflow at M10 (format validation).
- If a pattern emerges where \"macOS on Namespace via \`shipyard ship\`\" would beat \"macOS local + \`shipyard cloud run\` separately,\" file it as a Shipyard FR (new \`backend = \"namespace\"\` option on a target).