### PR TITLE
Milestones 8 + 9 — Snapshot A/B + morph + preset file format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SPECTR_SOURCES
     src/block_fft_engine.cpp
     src/edit_engine.cpp
     src/pattern.cpp
+    src/preset_format.cpp
     src/snapshot.cpp
     src/ui/editor_view.cpp
 )
@@ -27,6 +28,7 @@ set(SPECTR_HEADERS
     include/spectr/viewport.hpp
     include/spectr/engine.hpp
     include/spectr/edit_modes.hpp
+    include/spectr/preset_format.hpp
     include/spectr/snapshot.hpp
     include/spectr/ui/editor_view.hpp
 )
@@ -59,6 +61,7 @@ add_executable(Spectr-test
     test/test_m4_state.cpp
     test/test_edit_engine.cpp
     test/test_pattern.cpp
+    test/test_preset.cpp
     test/test_snapshot.cpp
     ${SPECTR_SOURCES}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SPECTR_SOURCES
     src/block_fft_engine.cpp
     src/edit_engine.cpp
     src/pattern.cpp
+    src/snapshot.cpp
     src/ui/editor_view.cpp
 )
 
@@ -26,6 +27,7 @@ set(SPECTR_HEADERS
     include/spectr/viewport.hpp
     include/spectr/engine.hpp
     include/spectr/edit_modes.hpp
+    include/spectr/snapshot.hpp
     include/spectr/ui/editor_view.hpp
 )
 
@@ -57,6 +59,7 @@ add_executable(Spectr-test
     test/test_m4_state.cpp
     test/test_edit_engine.cpp
     test/test_pattern.cpp
+    test/test_snapshot.cpp
     ${SPECTR_SOURCES}
 )
 target_link_libraries(Spectr-test PRIVATE

--- a/include/spectr/preset_format.hpp
+++ b/include/spectr/preset_format.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+// Spectr-owned preset file format (Milestone 9).
+//
+// Per V2 handoff §7, Spectr persists presets through its own JSON
+// wrapper rather than PresetManager's default format. The wrapper
+// bundles four pieces so a round-trip always restores the full sound:
+//
+//   - StateStore blob: flat automatable parameters (Mix, Output,
+//     Response, Engine, Bands, Morph). Binary bytes are base64-encoded
+//     before landing in the JSON.
+//   - Plugin state: the supplemental blob (§5.4), which carries the
+//     canonical BandField, viewport, layout, and the A/B snapshot
+//     bank. Already JSON text — embedded as a nested object.
+//   - Schema version: enables clear migration errors when loading an
+//     older preset whose shape this build doesn't recognize.
+//   - Metadata: name + author + description + ISO-8601 timestamps, so
+//     the file stays useful outside Spectr (pattern libraries, preset
+//     browsers, external tooling).
+//
+// Writers always emit the current schema. Readers accept the current
+// schema exactly and report a migration error on any other version —
+// there's no silent downgrade path.
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pulp::format { class Processor; }
+
+namespace spectr {
+
+/// Per-preset human-facing metadata. All fields optional; the file is
+/// valid even if everything here is empty.
+struct PresetMetadata {
+    std::string name;
+    std::string author;
+    std::string description;
+    /// ISO-8601 UTC. Empty on unset.
+    std::string created_at;
+    std::string modified_at;
+};
+
+/// Preset file schema version. Bump when the file shape changes
+/// incompatibly; the reader rejects mismatches with a migration error.
+inline constexpr int kPresetSchemaVersion = 1;
+
+/// Distinct failure modes a caller might want to surface.
+enum class PresetLoadError : std::uint8_t {
+    None             = 0,
+    MalformedJson    = 1,
+    NotASpectrPreset = 2,  ///< `format` field missing or not "spectr.preset"
+    SchemaMismatch   = 3,  ///< schema_version doesn't match kPresetSchemaVersion
+    MissingState     = 4,  ///< state.state_store or state.plugin_state missing
+    CorruptState     = 5,  ///< base64 decode or plugin_state parse failed
+};
+
+/// Encode a preset to a JSON string from the current processor state.
+/// Works on any processor that is bound to a StateStore and implements
+/// the Spectr plugin-state hooks; in practice this is always Spectr.
+std::string save_preset_to_string(const pulp::format::Processor& proc,
+                                  const PresetMetadata& metadata);
+
+struct PresetLoadResult {
+    PresetLoadError error = PresetLoadError::None;
+    PresetMetadata  metadata{};
+    int             file_schema_version = 0;
+    std::string     plugin_version;
+
+    explicit operator bool() const noexcept { return error == PresetLoadError::None; }
+};
+
+/// Decode a preset JSON string and apply it to the processor. On
+/// success, both StateStore and plugin-owned supplemental state are
+/// restored; on failure, the processor is left untouched.
+PresetLoadResult load_preset_from_string(pulp::format::Processor& proc,
+                                         std::string_view json);
+
+/// Convenience wrappers for on-disk preset files. Return an optional
+/// for save (nullopt = file-system error) and the same result struct
+/// for load (error set on file-system failures).
+bool             save_preset_to_file(const pulp::format::Processor& proc,
+                                     const PresetMetadata& metadata,
+                                     const std::string& path);
+PresetLoadResult load_preset_from_file(pulp::format::Processor& proc,
+                                       const std::string& path);
+
+/// Human-readable message for a given error. Stable strings, safe to
+/// show in UI. "None" returns "ok".
+const char* describe(PresetLoadError e) noexcept;
+
+} // namespace spectr

--- a/include/spectr/snapshot.hpp
+++ b/include/spectr/snapshot.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+// Snapshot A/B + morph (Milestone 8).
+//
+// Spectr captures the complete sound-defining state into two slots
+// (A and B) and can interpolate between them on the canonical 64-slot
+// band model. The bank itself is plugin-owned and rides the
+// supplemental plugin-state blob (§5.4 of the V2 handoff), so it
+// survives host session reload alongside the live BandField and
+// viewport. StateStore snapshots of the flat params are a separate
+// concern handled by `pulp::view::ABCompare` over the processor's
+// StateStore — see Spectr::ab_compare().
+//
+// For V1, a "snapshot" holds:
+//   - the 64-slot BandField (per-band gain_db + muted)
+//   - the viewport bounds
+//   - the selected layout (so switching layouts doesn't quietly drop
+//     bands during a morph)
+//
+// Morph interpolates per-band gain_db linearly in dB space (matches
+// the slider's mental model: at t=0.5 the gain sits halfway between
+// A and B in dB terms). Mute state is picked from whichever slot
+// dominates at the current t (A below 0.5, B at/above). Viewport and
+// layout do NOT morph continuously — they snap to whichever slot
+// dominates to avoid nonsensical fractional band counts.
+
+#include <array>
+#include <cstddef>
+
+#include "spectr/band_state.hpp"
+#include "spectr/viewport.hpp"
+
+namespace spectr {
+
+/// Complete sound-defining state captured into a single slot.
+struct FieldSnapshot {
+    BandField field{};
+    Viewport  viewport{};
+    Layout    layout = Layout::Bands32;
+
+    /// True once the slot has been populated at least once. Empty
+    /// slots should not be fed to morph_fields; dispatch guards
+    /// against it and falls back to the populated side.
+    bool populated = false;
+};
+
+/// Two-slot snapshot bank.
+struct SnapshotBank {
+    enum class Slot : std::uint8_t { A = 0, B = 1 };
+
+    FieldSnapshot a{};
+    FieldSnapshot b{};
+
+    /// Which slot is considered "active" for edits. UI decides what
+    /// this means visually; the bank just stores the bit so the
+    /// selection survives session reload.
+    Slot active = Slot::A;
+
+    FieldSnapshot&       get(Slot s)       noexcept { return s == Slot::A ? a : b; }
+    const FieldSnapshot& get(Slot s) const noexcept { return s == Slot::A ? a : b; }
+
+    /// Copy `current` into the named slot and mark it populated.
+    void capture_into(Slot s, const BandField& current_field,
+                      const Viewport& current_viewport,
+                      Layout current_layout) noexcept {
+        auto& dst = get(s);
+        dst.field     = current_field;
+        dst.viewport  = current_viewport;
+        dst.layout    = current_layout;
+        dst.populated = true;
+    }
+
+    /// Copy src → dst (mirroring `pulp::view::ABCompare::copy`).
+    void copy(Slot src, Slot dst) noexcept {
+        if (src == dst) return;
+        get(dst) = get(src);
+    }
+
+    /// Swap A and B in place.
+    void swap() noexcept { std::swap(a, b); }
+
+    bool has(Slot s) const noexcept { return get(s).populated; }
+};
+
+/// Interpolate two BandFields at t ∈ [0, 1] into `out`. Values outside
+/// the range are clamped. Per-band gain_db is a simple linear lerp in
+/// dB space; mute state is A below 0.5 and B at/above 0.5.
+///
+/// Safe to call with `out` aliasing `a` or `b` — every slot is read
+/// before the corresponding slot is written.
+void morph_fields(BandField& out,
+                  const BandField& a,
+                  const BandField& b,
+                  float t) noexcept;
+
+} // namespace spectr

--- a/include/spectr/spectr.hpp
+++ b/include/spectr/spectr.hpp
@@ -8,12 +8,14 @@
 // Milestone 4.
 
 #include <pulp/format/processor.hpp>
+#include <pulp/view/ab_compare.hpp>
 #include <pulp/view/visualization_bridge.hpp>
 #include <memory>
 
 #include "spectr/band_state.hpp"
 #include "spectr/edit_modes.hpp"
 #include "spectr/engine.hpp"
+#include "spectr/snapshot.hpp"
 #include "spectr/viewport.hpp"
 
 namespace spectr {
@@ -24,6 +26,7 @@ enum ParamIDs : pulp::state::ParamID {
     kResponseMode = 3,   ///< 0=Live, 1=Precision
     kEngineMode   = 4,   ///< 0=IIR, 1=FFT, 2=Hybrid
     kBandCount    = 5,   ///< 0=32, 1=40, 2=48, 3=56, 4=64
+    kMorph        = 6,   ///< [0, 1], 0=A, 1=B (Milestone 8)
 };
 
 inline pulp::format::PluginDescriptor make_descriptor() {
@@ -68,7 +71,11 @@ public:
     /// Supplemental-state schema version. Bump when the JSON shape changes
     /// in a non-backward-compatible way; deserialize rejects unknown
     /// versions.
-    static constexpr int kPluginStateVersion = 1;
+    ///
+    /// v2 (M8) extends v1 with an optional `snapshots` object holding the
+    /// A/B snapshot bank. Absent `snapshots` is legal — reading a v1 blob
+    /// is always a reset-to-default for the bank.
+    static constexpr int kPluginStateVersion = 2;
 
     // ── Editor view ────────────────────────────────────────────────────
     std::unique_ptr<pulp::view::View> create_view() override;
@@ -97,6 +104,37 @@ public:
     void set_response_mode(ResponseMode m) noexcept { response_mode_ = m; }
     void set_engine_kind(EngineKind k);
 
+    // ── Snapshot A/B + morph (Milestone 8) ──────────────────────────────
+    //
+    // Spectr tracks two kinds of A/B state:
+    //
+    //   - Flat StateStore params (Mix, Output, Response, Engine, Bands,
+    //     Morph itself): handled by pulp::view::ABCompare over the
+    //     StateStore. Access via ab_compare().
+    //   - Band-field + viewport + layout: held in snapshots_ below, with
+    //     per-band morph via morph_fields(). Serialized in the plugin
+    //     state blob so it survives session reload.
+    //
+    // UI drives both in lockstep for the full A/B experience.
+
+    const SnapshotBank& snapshots() const noexcept { return snapshots_; }
+    SnapshotBank&       snapshots()       noexcept { return snapshots_; }
+
+    /// Copy the current field + viewport + layout into the named slot.
+    /// Marks the slot populated.
+    void capture_snapshot(SnapshotBank::Slot slot) noexcept;
+
+    /// Write the morph of A and B at t into `field_`. If either slot is
+    /// unpopulated, falls back to the populated side (or leaves field_
+    /// alone if neither slot has been captured). Does NOT touch viewport
+    /// or layout — those aren't continuously morphed.
+    void apply_morph_to_live(float t) noexcept;
+
+    /// Accessor for the StateStore-level ABCompare. Lazily constructed
+    /// the first time it's requested (after define_parameters has wired
+    /// the store). Returns nullptr if the store isn't available yet.
+    pulp::view::ABCompare* ab_compare() noexcept;
+
     // ── Analyzer bridge — UI-thread read path ───────────────────────────
     //
     // Spectr publishes STFT + meter + waveform snapshots from the audio
@@ -119,7 +157,9 @@ private:
     EngineKind                       engine_kind_  = EngineKind::Fft;
     std::unique_ptr<SpectralEngine>  engine_{};
 
-    pulp::view::VisualizationBridge  bridge_{};
+    pulp::view::VisualizationBridge       bridge_{};
+    SnapshotBank                          snapshots_{};
+    std::unique_ptr<pulp::view::ABCompare> ab_{};
 
     void rebuild_engine_();
     void configure_bridge_(int num_channels);

--- a/src/preset_format.cpp
+++ b/src/preset_format.cpp
@@ -1,0 +1,214 @@
+#include "spectr/preset_format.hpp"
+#include "spectr/spectr.hpp"
+
+#include <pulp/format/processor.hpp>
+#include <pulp/runtime/base64.hpp>
+#include <pulp/state/store.hpp>
+
+#include <choc/containers/choc_Value.h>
+#include <choc/text/choc_JSON.h>
+
+#include <fstream>
+#include <sstream>
+#include <string_view>
+
+namespace spectr {
+
+namespace {
+
+constexpr const char* kFormatTag = "spectr.preset";
+
+/// Emit the supplemental plugin-state blob as a parsed JSON object,
+/// embedded inline rather than stringified. Returns a default empty
+/// object if the blob is not valid JSON (shouldn't happen under normal
+/// flow — Spectr always emits well-formed JSON).
+choc::value::Value plugin_state_as_object_(const pulp::format::Processor& proc) {
+    const auto bytes = proc.serialize_plugin_state();
+    if (bytes.empty()) return choc::value::createObject("EmptyPluginState");
+    const std::string_view text(reinterpret_cast<const char*>(bytes.data()),
+                                bytes.size());
+    try {
+        return choc::json::parse(text);
+    } catch (...) {
+        return choc::value::createObject("EmptyPluginState");
+    }
+}
+
+std::string read_file_(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f.good()) return {};
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+bool write_file_(const std::string& path, const std::string& contents) {
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f.good()) return false;
+    f.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    return f.good();
+}
+
+std::string get_string_(const choc::value::ValueView& v, const char* key) {
+    if (!v.isObject() || !v.hasObjectMember(key)) return {};
+    const auto e = v[key];
+    if (!e.isString()) return {};
+    return std::string(e.getString());
+}
+
+} // namespace
+
+// ── Save ───────────────────────────────────────────────────────────────
+
+std::string save_preset_to_string(const pulp::format::Processor& proc,
+                                  const PresetMetadata& metadata)
+{
+    using choc::value::createObject;
+
+    auto root = createObject("SpectrPreset");
+    root.addMember("format",          kFormatTag);
+    root.addMember("schema_version",  static_cast<int32_t>(kPresetSchemaVersion));
+    root.addMember("plugin_version",  proc.descriptor().version);
+
+    auto meta = createObject("Metadata");
+    meta.addMember("name",        metadata.name);
+    meta.addMember("author",      metadata.author);
+    meta.addMember("description", metadata.description);
+    meta.addMember("created_at",  metadata.created_at);
+    meta.addMember("modified_at", metadata.modified_at);
+    root.addMember("metadata", meta);
+
+    auto state = createObject("State");
+    // StateStore blob — binary, base64-encode for transport through JSON.
+    const auto store_bytes = proc.state().serialize();
+    const std::string store_b64 =
+        pulp::runtime::base64_encode(store_bytes.data(), store_bytes.size());
+    state.addMember("state_store", store_b64);
+    // Plugin supplemental state — already JSON text, embed as object.
+    state.addMember("plugin_state", plugin_state_as_object_(proc));
+    root.addMember("state", state);
+
+    return choc::json::toString(root, /*useLineBreaks=*/true);
+}
+
+bool save_preset_to_file(const pulp::format::Processor& proc,
+                         const PresetMetadata& metadata,
+                         const std::string& path)
+{
+    return write_file_(path, save_preset_to_string(proc, metadata));
+}
+
+// ── Load ───────────────────────────────────────────────────────────────
+
+PresetLoadResult load_preset_from_string(pulp::format::Processor& proc,
+                                         std::string_view json)
+{
+    PresetLoadResult r;
+
+    choc::value::Value root;
+    try {
+        root = choc::json::parse(json);
+    } catch (...) {
+        r.error = PresetLoadError::MalformedJson;
+        return r;
+    }
+    if (!root.isObject()) { r.error = PresetLoadError::MalformedJson; return r; }
+
+    // format tag.
+    if (!root.hasObjectMember("format")) {
+        r.error = PresetLoadError::NotASpectrPreset; return r;
+    }
+    const auto fmt = root["format"];
+    if (!fmt.isString() || fmt.getString() != kFormatTag) {
+        r.error = PresetLoadError::NotASpectrPreset; return r;
+    }
+
+    // Schema version — must match exactly. No silent downgrade.
+    int schema = 0;
+    if (root.hasObjectMember("schema_version")) {
+        const auto e = root["schema_version"];
+        if      (e.isInt32())   schema = e.getInt32();
+        else if (e.isInt64())   schema = static_cast<int>(e.getInt64());
+        else if (e.isFloat64()) schema = static_cast<int>(e.getFloat64());
+    }
+    r.file_schema_version = schema;
+    if (schema != kPresetSchemaVersion) {
+        r.error = PresetLoadError::SchemaMismatch; return r;
+    }
+
+    // Metadata — purely informational, failure to read is not fatal.
+    if (root.hasObjectMember("metadata") && root["metadata"].isObject()) {
+        const auto m = root["metadata"];
+        r.metadata.name        = get_string_(m, "name");
+        r.metadata.author      = get_string_(m, "author");
+        r.metadata.description = get_string_(m, "description");
+        r.metadata.created_at  = get_string_(m, "created_at");
+        r.metadata.modified_at = get_string_(m, "modified_at");
+    }
+    r.plugin_version = get_string_(root, "plugin_version");
+
+    // State block — both halves required.
+    if (!root.hasObjectMember("state") || !root["state"].isObject()) {
+        r.error = PresetLoadError::MissingState; return r;
+    }
+    const auto state = root["state"];
+    if (!state.hasObjectMember("state_store") || !state.hasObjectMember("plugin_state")) {
+        r.error = PresetLoadError::MissingState; return r;
+    }
+
+    // Decode StateStore blob.
+    const auto store_view = state["state_store"];
+    if (!store_view.isString()) { r.error = PresetLoadError::CorruptState; return r; }
+    const auto store_decoded = pulp::runtime::base64_decode(std::string_view(store_view.getString()));
+    if (!store_decoded) { r.error = PresetLoadError::CorruptState; return r; }
+
+    // Re-serialize the plugin_state subtree back to JSON text so we can
+    // feed it through the Processor's existing deserialize hook without
+    // reinventing its parse path here.
+    const auto plugin_state_json =
+        choc::json::toString(state["plugin_state"], /*useLineBreaks=*/false);
+    const std::vector<uint8_t> plugin_state_bytes(plugin_state_json.begin(),
+                                                  plugin_state_json.end());
+
+    // Apply. StateStore first — deserialize fills the atomics. Plugin
+    // state second so handlers that read params during their apply see
+    // the restored flat state.
+    if (!proc.state().deserialize(std::span<const uint8_t>(store_decoded->data(),
+                                                           store_decoded->size()))) {
+        r.error = PresetLoadError::CorruptState; return r;
+    }
+    if (!proc.deserialize_plugin_state(std::span<const uint8_t>(plugin_state_bytes.data(),
+                                                                plugin_state_bytes.size()))) {
+        r.error = PresetLoadError::CorruptState; return r;
+    }
+
+    return r;
+}
+
+PresetLoadResult load_preset_from_file(pulp::format::Processor& proc,
+                                       const std::string& path)
+{
+    const auto contents = read_file_(path);
+    if (contents.empty()) {
+        PresetLoadResult r;
+        r.error = PresetLoadError::MalformedJson;
+        return r;
+    }
+    return load_preset_from_string(proc, contents);
+}
+
+// ── Error descriptions ────────────────────────────────────────────────
+
+const char* describe(PresetLoadError e) noexcept {
+    switch (e) {
+        case PresetLoadError::None:             return "ok";
+        case PresetLoadError::MalformedJson:    return "preset file is not valid JSON";
+        case PresetLoadError::NotASpectrPreset: return "file is not a Spectr preset (format tag missing or wrong)";
+        case PresetLoadError::SchemaMismatch:   return "preset was saved by a different Spectr schema — migrate it through the version that wrote it";
+        case PresetLoadError::MissingState:     return "preset is missing required state blocks";
+        case PresetLoadError::CorruptState:     return "preset state failed to decode — file may be corrupt";
+    }
+    return "unknown error";
+}
+
+} // namespace spectr

--- a/src/snapshot.cpp
+++ b/src/snapshot.cpp
@@ -1,0 +1,23 @@
+#include "spectr/snapshot.hpp"
+
+#include <algorithm>
+
+namespace spectr {
+
+void morph_fields(BandField& out,
+                  const BandField& a,
+                  const BandField& b,
+                  float t) noexcept
+{
+    t = std::clamp(t, 0.0f, 1.0f);
+    const bool b_dominant = (t >= 0.5f);
+
+    for (std::size_t i = 0; i < kMaxBands; ++i) {
+        const auto& ai = a.bands[i];
+        const auto& bi = b.bands[i];
+        out.bands[i].gain_db = ai.gain_db + (bi.gain_db - ai.gain_db) * t;
+        out.bands[i].muted   = b_dominant ? bi.muted : ai.muted;
+    }
+}
+
+} // namespace spectr

--- a/src/spectr.cpp
+++ b/src/spectr.cpp
@@ -72,6 +72,39 @@ void Spectr::define_parameters(pulp::state::StateStore& store) {
         .unit  = "",
         .range = {0.0f, 4.0f, 0.0f},   // default 32-band layout
     });
+    store.add_parameter({
+        .id    = kMorph,
+        .name  = "Morph",
+        .unit  = "",
+        .range = {0.0f, 1.0f, 0.0f},   // default A (no morph)
+    });
+
+    // Wire ABCompare now that the store reference is live. Keeps the
+    // StateStore-side A/B under pulp::view::ABCompare and the band-field
+    // side under SnapshotBank — UI drives both together.
+    ab_ = std::make_unique<pulp::view::ABCompare>(&store);
+}
+
+// ── Snapshot A/B (Milestone 8) ─────────────────────────────────────────
+
+void Spectr::capture_snapshot(SnapshotBank::Slot slot) noexcept {
+    snapshots_.capture_into(slot, field_, viewport_, layout_);
+}
+
+void Spectr::apply_morph_to_live(float t) noexcept {
+    const bool has_a = snapshots_.has(SnapshotBank::Slot::A);
+    const bool has_b = snapshots_.has(SnapshotBank::Slot::B);
+    if (!has_a && !has_b) return;
+    if (!has_a) { field_ = snapshots_.b.field; return; }
+    if (!has_b) { field_ = snapshots_.a.field; return; }
+    morph_fields(field_, snapshots_.a.field, snapshots_.b.field, t);
+}
+
+pulp::view::ABCompare* Spectr::ab_compare() noexcept {
+    // Constructed in define_parameters once the StateStore reference is
+    // live. Callers that invoke this before define_parameters get a
+    // nullptr — don't dereference without checking.
+    return ab_.get();
 }
 
 void Spectr::prepare(const pulp::format::PrepareContext& ctx) {
@@ -213,6 +246,33 @@ void Spectr::process(
 
 // ── Supplemental plugin state (pulp#625) ──────────────────────────────
 
+namespace {
+
+// Turn a FieldSnapshot into a JSON object. Symmetric with
+// read_snapshot_() below.
+choc::value::Value write_snapshot_(const FieldSnapshot& s) {
+    using choc::value::createObject;
+    using choc::value::createEmptyArray;
+
+    auto obj = createObject("FieldSnapshot");
+    obj.addMember("populated", s.populated);
+
+    auto gains = createEmptyArray();
+    auto mutes = createEmptyArray();
+    for (const auto& b : s.field.bands) {
+        gains.addArrayElement(static_cast<double>(b.gain_db));
+        mutes.addArrayElement(b.muted);
+    }
+    obj.addMember("band_gain", gains);
+    obj.addMember("band_mute", mutes);
+    obj.addMember("view_min_hz", static_cast<double>(s.viewport.min_hz));
+    obj.addMember("view_max_hz", static_cast<double>(s.viewport.max_hz));
+    obj.addMember("layout_index", static_cast<int32_t>(layout_to_index(s.layout)));
+    return obj;
+}
+
+} // namespace
+
 std::vector<uint8_t> Spectr::serialize_plugin_state() const {
     using choc::value::createObject;
     using choc::value::createEmptyArray;
@@ -244,16 +304,88 @@ std::vector<uint8_t> Spectr::serialize_plugin_state() const {
     root.addMember("analyzer_mode", static_cast<int32_t>(0));
     root.addMember("edit_mode",     static_cast<int32_t>(0));
 
+    // M8 — snapshot bank. Absent or empty on a v1 blob; new v2 writers
+    // always include it so a round-trip preserves the A/B selection
+    // across session reloads.
+    auto snaps = createObject("SnapshotBank");
+    snaps.addMember("active", static_cast<int32_t>(snapshots_.active));
+    snaps.addMember("a", write_snapshot_(snapshots_.a));
+    snaps.addMember("b", write_snapshot_(snapshots_.b));
+    root.addMember("snapshots", snaps);
+
     auto json = choc::json::toString(root, /*useLineBreaks=*/false);
     return {json.begin(), json.end()};
 }
 
 namespace {
 
-void reset_supplemental_state_(BandField& f, Viewport& v, Layout& l) {
+void reset_supplemental_state_(BandField& f, Viewport& v, Layout& l,
+                               SnapshotBank& bank) {
     f.reset();
     v = Viewport{};
     l = Layout::Bands32;
+    bank = SnapshotBank{};
+}
+
+// Symmetric with write_snapshot_(). Returns true if `obj` was read
+// into `dst` without error. An unpopulated slot (empty object, or
+// `populated == false`) resets dst to default.
+//
+// Takes a ValueView (what `parent["key"]` returns) rather than a Value
+// so callers don't have to copy the subtree out of the parent.
+bool read_snapshot_(const choc::value::ValueView& obj, FieldSnapshot& dst) {
+    if (!obj.isObject()) { dst = FieldSnapshot{}; return true; }
+
+    FieldSnapshot staged{};
+    staged.populated = false;
+
+    if (obj.hasObjectMember("populated")) {
+        const auto e = obj["populated"];
+        staged.populated = e.isBool() ? e.getBool() : false;
+    }
+    if (obj.hasObjectMember("band_gain") && obj["band_gain"].isArray()) {
+        auto arr = obj["band_gain"];
+        const auto n = std::min<std::uint32_t>(arr.size(), kMaxBands);
+        for (std::uint32_t i = 0; i < n; ++i) {
+            const auto e = arr[i];
+            float g = 0.0f;
+            if      (e.isFloat64()) g = static_cast<float>(e.getFloat64());
+            else if (e.isInt64())   g = static_cast<float>(e.getInt64());
+            else if (e.isInt32())   g = static_cast<float>(e.getInt32());
+            staged.field.bands[i].gain_db = g;
+        }
+    }
+    if (obj.hasObjectMember("band_mute") && obj["band_mute"].isArray()) {
+        auto arr = obj["band_mute"];
+        const auto n = std::min<std::uint32_t>(arr.size(), kMaxBands);
+        for (std::uint32_t i = 0; i < n; ++i) {
+            const auto e = arr[i];
+            staged.field.bands[i].muted = e.isBool() ? e.getBool() : false;
+        }
+    }
+    if (obj.hasObjectMember("view_min_hz")) {
+        const auto e = obj["view_min_hz"];
+        if      (e.isFloat64()) staged.viewport.min_hz = static_cast<float>(e.getFloat64());
+        else if (e.isInt64())   staged.viewport.min_hz = static_cast<float>(e.getInt64());
+    }
+    if (obj.hasObjectMember("view_max_hz")) {
+        const auto e = obj["view_max_hz"];
+        if      (e.isFloat64()) staged.viewport.max_hz = static_cast<float>(e.getFloat64());
+        else if (e.isInt64())   staged.viewport.max_hz = static_cast<float>(e.getInt64());
+    }
+    if (!staged.viewport.valid()) staged.viewport = Viewport{};
+    if (obj.hasObjectMember("layout_index")) {
+        const auto e = obj["layout_index"];
+        int idx = 0;
+        if      (e.isInt32())   idx = e.getInt32();
+        else if (e.isInt64())   idx = static_cast<int>(e.getInt64());
+        else if (e.isFloat64()) idx = static_cast<int>(e.getFloat64());
+        idx = std::clamp(idx, 0, static_cast<int>(kLayoutCount) - 1);
+        staged.layout = kLayoutValues[static_cast<std::size_t>(idx)];
+    }
+
+    dst = staged;
+    return true;
 }
 
 } // namespace
@@ -262,7 +394,7 @@ bool Spectr::deserialize_plugin_state(std::span<const uint8_t> bytes) {
     // Empty span = legacy blob or caller signalling "reset to defaults"
     // per the pulp#625 hook contract.
     if (bytes.empty()) {
-        reset_supplemental_state_(field_, viewport_, layout_);
+        reset_supplemental_state_(field_, viewport_, layout_, snapshots_);
         return true;
     }
 
@@ -275,7 +407,8 @@ bool Spectr::deserialize_plugin_state(std::span<const uint8_t> bytes) {
     }
     if (!root.isObject()) return false;
 
-    // Version gate — reject anything we don't know how to read.
+    // Version gate — accept v1 (legacy pre-M8) and v2 (with snapshots).
+    // Reject anything else we don't know how to read.
     if (!root.hasObjectMember("version")) return false;
     const auto v = root["version"];
     int version = 0;
@@ -283,7 +416,7 @@ bool Spectr::deserialize_plugin_state(std::span<const uint8_t> bytes) {
     else if (v.isInt64())    version = static_cast<int>(v.getInt64());
     else if (v.isFloat64())  version = static_cast<int>(v.getFloat64());
     else                     return false;
-    if (version != kPluginStateVersion) return false;
+    if (version < 1 || version > kPluginStateVersion) return false;
 
     // Apply in a staging copy so a malformed payload leaves live state alone.
     BandField new_field;
@@ -333,8 +466,26 @@ bool Spectr::deserialize_plugin_state(std::span<const uint8_t> bytes) {
     // Viewport sanity — fall back to defaults on garbage values.
     if (!new_view.valid()) new_view = Viewport{};
 
-    field_    = new_field;
-    viewport_ = new_view;
+    // M8 — snapshot bank (version 2+). Absent or malformed resets the
+    // bank to empty; a well-formed block round-trips exactly.
+    SnapshotBank new_bank{};
+    if (version >= 2 && root.hasObjectMember("snapshots") && root["snapshots"].isObject()) {
+        const auto snaps = root["snapshots"];
+        if (snaps.hasObjectMember("active")) {
+            const auto e = snaps["active"];
+            int a = 0;
+            if      (e.isInt32())   a = e.getInt32();
+            else if (e.isInt64())   a = static_cast<int>(e.getInt64());
+            else if (e.isFloat64()) a = static_cast<int>(e.getFloat64());
+            new_bank.active = (a == 1) ? SnapshotBank::Slot::B : SnapshotBank::Slot::A;
+        }
+        if (snaps.hasObjectMember("a")) read_snapshot_(snaps["a"], new_bank.a);
+        if (snaps.hasObjectMember("b")) read_snapshot_(snaps["b"], new_bank.b);
+    }
+
+    field_     = new_field;
+    viewport_  = new_view;
+    snapshots_ = new_bank;
     if (new_layout != layout_) set_layout(new_layout);
     return true;
 }

--- a/test/test_preset.cpp
+++ b/test/test_preset.cpp
@@ -1,0 +1,193 @@
+// Milestone 9 — Preset file format.
+//
+// Coverage:
+//   - save → load → round-trip matches working state exactly (both
+//     StateStore params and plugin-owned supplemental state).
+//   - Schema-mismatch rejection with a clear migration error.
+//   - Corrupt / malformed file handling.
+//   - Metadata round-trip (name / author / description / timestamps).
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "spectr/preset_format.hpp"
+#include "spectr/spectr.hpp"
+#include "spectr/snapshot.hpp"
+
+#include <pulp/state/store.hpp>
+
+#include <string>
+
+using Catch::Approx;
+using spectr::Spectr;
+using spectr::SnapshotBank;
+using spectr::PresetLoadError;
+using spectr::PresetMetadata;
+using spectr::save_preset_to_string;
+using spectr::load_preset_from_string;
+using spectr::kPresetSchemaVersion;
+
+namespace {
+
+struct Rig {
+    pulp::state::StateStore store;
+    std::unique_ptr<Spectr>  proc;
+
+    Rig() : proc(std::make_unique<Spectr>()) {
+        proc->set_state_store(&store);
+        proc->define_parameters(store);
+    }
+};
+
+} // namespace
+
+TEST_CASE("M9 preset round-trip preserves working state") {
+    Rig a;
+    // Build a non-default state across both flat params and supplemental.
+    a.store.set_value(spectr::kMix,        42.0f);
+    a.store.set_value(spectr::kOutputTrim,  6.0f);
+    a.store.set_value(spectr::kMorph,       0.33f);
+    a.proc->field().bands[7].gain_db  = -9.0f;
+    a.proc->field().bands[42].muted   = true;
+    a.proc->viewport().min_hz = 120.0f;
+    a.proc->viewport().max_hz = 7200.0f;
+    a.proc->set_layout(spectr::Layout::Bands56);
+
+    // Capture into both snapshot slots so the preset exercises the full
+    // bank round-trip path too.
+    a.proc->capture_snapshot(SnapshotBank::Slot::A);
+    a.proc->field() = spectr::BandField{};
+    a.proc->field().bands[0].gain_db = +6.0f;
+    a.proc->capture_snapshot(SnapshotBank::Slot::B);
+    a.proc->snapshots().active = SnapshotBank::Slot::B;
+
+    PresetMetadata meta;
+    meta.name = "RoundTrip Test";
+    meta.author = "M9";
+    meta.description = "Exercises every M9 round-trip path.";
+    meta.created_at = "2026-04-23T19:00:00Z";
+    meta.modified_at = "2026-04-23T19:00:05Z";
+
+    const std::string json = save_preset_to_string(*a.proc, meta);
+    REQUIRE_FALSE(json.empty());
+
+    Rig b;
+    const auto result = load_preset_from_string(*b.proc, json);
+    REQUIRE(result);
+    CHECK(result.error == PresetLoadError::None);
+    CHECK(result.file_schema_version == kPresetSchemaVersion);
+    CHECK(result.metadata.name        == "RoundTrip Test");
+    CHECK(result.metadata.author      == "M9");
+    CHECK(result.metadata.description == "Exercises every M9 round-trip path.");
+    CHECK(result.metadata.created_at  == "2026-04-23T19:00:00Z");
+    CHECK(result.metadata.modified_at == "2026-04-23T19:00:05Z");
+
+    // Flat params restored.
+    CHECK(b.store.get_value(spectr::kMix)        == Approx(42.0f));
+    CHECK(b.store.get_value(spectr::kOutputTrim) == Approx(6.0f));
+    CHECK(b.store.get_value(spectr::kMorph)      == Approx(0.33f));
+
+    // Supplemental state restored.
+    CHECK(b.proc->field().bands[0].gain_db == Approx(+6.0f));  // live field = B's snapshot
+    CHECK(b.proc->viewport().min_hz == Approx(120.0f));
+    CHECK(b.proc->viewport().max_hz == Approx(7200.0f));
+    CHECK(b.proc->layout() == spectr::Layout::Bands56);
+
+    // Snapshot bank restored.
+    CHECK(b.proc->snapshots().has(SnapshotBank::Slot::A));
+    CHECK(b.proc->snapshots().has(SnapshotBank::Slot::B));
+    CHECK(b.proc->snapshots().a.field.bands[7].gain_db  == Approx(-9.0f));
+    CHECK(b.proc->snapshots().a.field.bands[42].muted   == true);
+    CHECK(b.proc->snapshots().b.field.bands[0].gain_db  == Approx(+6.0f));
+    CHECK(b.proc->snapshots().active == SnapshotBank::Slot::B);
+}
+
+TEST_CASE("M9 schema mismatch returns a clear migration error") {
+    Rig r;
+
+    // Valid JSON, valid format tag, but schema_version = 999.
+    const std::string bad =
+        R"({"format":"spectr.preset","schema_version":999,"plugin_version":"1.0.0",)"
+        R"("metadata":{},)"
+        R"("state":{"state_store":"","plugin_state":{}}})";
+
+    const auto result = load_preset_from_string(*r.proc, bad);
+    CHECK_FALSE(result);
+    CHECK(result.error == PresetLoadError::SchemaMismatch);
+    CHECK(result.file_schema_version == 999);
+    // Message mentions migration path.
+    const std::string msg = spectr::describe(result.error);
+    CHECK(msg.find("schema") != std::string::npos);
+    CHECK(msg.find("migrate") != std::string::npos);
+}
+
+TEST_CASE("M9 rejects files that aren't Spectr presets") {
+    Rig r;
+    const std::string not_ours =
+        R"({"format":"someother.preset","schema_version":1})";
+    const auto result = load_preset_from_string(*r.proc, not_ours);
+    CHECK_FALSE(result);
+    CHECK(result.error == PresetLoadError::NotASpectrPreset);
+}
+
+TEST_CASE("M9 rejects malformed JSON without touching processor state") {
+    Rig r;
+    r.store.set_value(spectr::kMix, 50.0f);
+    r.proc->field().bands[0].gain_db = -3.0f;
+
+    const auto result = load_preset_from_string(*r.proc, "not json at all {");
+    CHECK_FALSE(result);
+    CHECK(result.error == PresetLoadError::MalformedJson);
+
+    // Original state unchanged.
+    CHECK(r.store.get_value(spectr::kMix) == Approx(50.0f));
+    CHECK(r.proc->field().bands[0].gain_db == Approx(-3.0f));
+}
+
+TEST_CASE("M9 reports MissingState when the state block is absent") {
+    Rig r;
+    const std::string no_state =
+        R"({"format":"spectr.preset","schema_version":1,"plugin_version":"1.0.0","metadata":{}})";
+    const auto result = load_preset_from_string(*r.proc, no_state);
+    CHECK_FALSE(result);
+    CHECK(result.error == PresetLoadError::MissingState);
+}
+
+TEST_CASE("M9 reports CorruptState on undecodable state_store") {
+    Rig r;
+    const std::string bad_b64 =
+        R"({"format":"spectr.preset","schema_version":1,"plugin_version":"1.0.0",)"
+        R"("metadata":{},)"
+        R"("state":{"state_store":"!!!not base64!!!","plugin_state":{}}})";
+    const auto result = load_preset_from_string(*r.proc, bad_b64);
+    CHECK_FALSE(result);
+    CHECK(result.error == PresetLoadError::CorruptState);
+}
+
+TEST_CASE("M9 file save/load round-trip works end-to-end") {
+    Rig a;
+    a.store.set_value(spectr::kMix, 25.0f);
+    a.proc->field().bands[3].gain_db = -5.0f;
+
+    const std::string path = "/tmp/spectr-m9-roundtrip.preset";
+    PresetMetadata meta;
+    meta.name = "File";
+    REQUIRE(spectr::save_preset_to_file(*a.proc, meta, path));
+
+    Rig b;
+    const auto result = spectr::load_preset_from_file(*b.proc, path);
+    REQUIRE(result);
+    CHECK(b.store.get_value(spectr::kMix) == Approx(25.0f));
+    CHECK(b.proc->field().bands[3].gain_db == Approx(-5.0f));
+    CHECK(result.metadata.name == "File");
+}
+
+TEST_CASE("M9 describe() returns non-empty stable messages for every error") {
+    using E = PresetLoadError;
+    for (E e : {E::None, E::MalformedJson, E::NotASpectrPreset,
+                E::SchemaMismatch, E::MissingState, E::CorruptState}) {
+        const char* msg = spectr::describe(e);
+        REQUIRE(msg != nullptr);
+        CHECK(std::string(msg).size() > 0);
+    }
+}

--- a/test/test_snapshot.cpp
+++ b/test/test_snapshot.cpp
@@ -1,0 +1,248 @@
+// Milestone 8 — Snapshot A/B + morph.
+//
+// Coverage:
+//   - morph_fields() end conditions, midpoint, and continuity.
+//   - SnapshotBank capture / copy / swap / populated bit.
+//   - Spectr::capture_snapshot + apply_morph_to_live integration.
+//   - Plugin-state round-trip preserves the bank (v2 format).
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "spectr/snapshot.hpp"
+#include "spectr/spectr.hpp"
+
+#include <pulp/state/store.hpp>
+
+#include <cmath>
+
+using Catch::Approx;
+using spectr::BandField;
+using spectr::FieldSnapshot;
+using spectr::Layout;
+using spectr::SnapshotBank;
+using spectr::Spectr;
+using spectr::Viewport;
+using spectr::kMaxBands;
+using spectr::morph_fields;
+
+namespace {
+
+BandField make_field(float constant) {
+    BandField f;
+    for (auto& b : f.bands) b.gain_db = constant;
+    return f;
+}
+
+BandField ramp_field(float start, float step) {
+    BandField f;
+    for (std::size_t i = 0; i < kMaxBands; ++i) {
+        f.bands[i].gain_db = start + static_cast<float>(i) * step;
+    }
+    return f;
+}
+
+} // namespace
+
+TEST_CASE("M8 morph_fields: t=0 returns A, t=1 returns B") {
+    const auto A = make_field(-12.0f);
+    const auto B = make_field(+6.0f);
+    BandField out;
+
+    morph_fields(out, A, B, 0.0f);
+    for (std::size_t i = 0; i < kMaxBands; ++i)
+        CHECK(out.bands[i].gain_db == Approx(-12.0f));
+
+    morph_fields(out, A, B, 1.0f);
+    for (std::size_t i = 0; i < kMaxBands; ++i)
+        CHECK(out.bands[i].gain_db == Approx(+6.0f));
+}
+
+TEST_CASE("M8 morph_fields: midpoint is arithmetic mean in dB space") {
+    const auto A = make_field(-12.0f);
+    const auto B = make_field(+6.0f);
+    BandField out;
+
+    morph_fields(out, A, B, 0.5f);
+    for (std::size_t i = 0; i < kMaxBands; ++i)
+        CHECK(out.bands[i].gain_db == Approx(-3.0f));
+}
+
+TEST_CASE("M8 morph_fields: continuity across a sweep") {
+    const auto A = ramp_field(-60.0f, 1.0f);
+    const auto B = ramp_field(+12.0f, -0.5f);
+    BandField out_prev, out_curr;
+
+    morph_fields(out_prev, A, B, 0.0f);
+    // Walk t from 0→1 in 0.05 steps; no two adjacent samples should
+    // jump more than (|B - A|)*0.05 + epsilon for any band.
+    for (float t = 0.05f; t <= 1.0f + 1e-4f; t += 0.05f) {
+        morph_fields(out_curr, A, B, t);
+        for (std::size_t i = 0; i < kMaxBands; ++i) {
+            const float maxA = std::max(A.bands[i].gain_db, B.bands[i].gain_db);
+            const float minA = std::min(A.bands[i].gain_db, B.bands[i].gain_db);
+            const float span = maxA - minA;
+            const float step = std::abs(out_curr.bands[i].gain_db - out_prev.bands[i].gain_db);
+            CHECK(step <= span * 0.05f + 1e-4f);
+        }
+        out_prev = out_curr;
+    }
+}
+
+TEST_CASE("M8 morph_fields: clamps t to [0, 1]") {
+    const auto A = make_field(-10.0f);
+    const auto B = make_field(+10.0f);
+    BandField out;
+
+    morph_fields(out, A, B, -5.0f);
+    CHECK(out.bands[0].gain_db == Approx(-10.0f));
+    morph_fields(out, A, B, +5.0f);
+    CHECK(out.bands[0].gain_db == Approx(+10.0f));
+}
+
+TEST_CASE("M8 morph_fields: mute follows the dominant slot") {
+    BandField A, B;
+    A.bands[0].muted = true;  A.bands[1].muted = false;
+    B.bands[0].muted = false; B.bands[1].muted = true;
+    BandField out;
+
+    morph_fields(out, A, B, 0.25f);
+    CHECK(out.bands[0].muted == true);   // A dominates
+    CHECK(out.bands[1].muted == false);  // A dominates
+
+    morph_fields(out, A, B, 0.75f);
+    CHECK(out.bands[0].muted == false);  // B dominates
+    CHECK(out.bands[1].muted == true);   // B dominates
+
+    morph_fields(out, A, B, 0.5f);
+    // 0.5 is the boundary — implementation picks B (>=). Document the
+    // choice in the test so changes are intentional.
+    CHECK(out.bands[0].muted == false);
+    CHECK(out.bands[1].muted == true);
+}
+
+TEST_CASE("M8 SnapshotBank: capture marks slot populated") {
+    SnapshotBank bank;
+    CHECK_FALSE(bank.has(SnapshotBank::Slot::A));
+    CHECK_FALSE(bank.has(SnapshotBank::Slot::B));
+
+    const auto f = make_field(-6.0f);
+    bank.capture_into(SnapshotBank::Slot::A, f, Viewport{}, Layout::Bands48);
+    CHECK(bank.has(SnapshotBank::Slot::A));
+    CHECK_FALSE(bank.has(SnapshotBank::Slot::B));
+    CHECK(bank.a.layout == Layout::Bands48);
+    CHECK(bank.a.field.bands[0].gain_db == Approx(-6.0f));
+}
+
+TEST_CASE("M8 SnapshotBank: copy + swap") {
+    SnapshotBank bank;
+    bank.capture_into(SnapshotBank::Slot::A, make_field(+3.0f), Viewport{}, Layout::Bands32);
+
+    bank.copy(SnapshotBank::Slot::A, SnapshotBank::Slot::B);
+    CHECK(bank.has(SnapshotBank::Slot::B));
+    CHECK(bank.b.field.bands[0].gain_db == Approx(+3.0f));
+
+    // Overwrite B, then swap.
+    bank.capture_into(SnapshotBank::Slot::B, make_field(-9.0f), Viewport{}, Layout::Bands64);
+    bank.swap();
+    CHECK(bank.a.field.bands[0].gain_db == Approx(-9.0f));
+    CHECK(bank.a.layout == Layout::Bands64);
+    CHECK(bank.b.field.bands[0].gain_db == Approx(+3.0f));
+    CHECK(bank.b.layout == Layout::Bands32);
+}
+
+TEST_CASE("M8 Spectr::apply_morph_to_live: no-op when both slots empty") {
+    Spectr s;
+    s.field().bands[0].gain_db = -4.0f;
+    s.apply_morph_to_live(0.5f);
+    CHECK(s.field().bands[0].gain_db == Approx(-4.0f));
+}
+
+TEST_CASE("M8 Spectr::apply_morph_to_live: single-populated slot wins") {
+    Spectr s;
+    s.field() = make_field(-4.0f);
+    s.capture_snapshot(SnapshotBank::Slot::A);        // A = -4 dB
+    s.field() = make_field(+2.0f);                    // live now mid-edit
+    CHECK(s.field().bands[0].gain_db == Approx(+2.0f));
+
+    s.apply_morph_to_live(1.0f);                      // B empty → A wins
+    CHECK(s.field().bands[0].gain_db == Approx(-4.0f));
+}
+
+TEST_CASE("M8 Spectr::apply_morph_to_live: mid-morph blends A and B") {
+    Spectr s;
+    s.field() = make_field(-10.0f);
+    s.capture_snapshot(SnapshotBank::Slot::A);
+    s.field() = make_field(+10.0f);
+    s.capture_snapshot(SnapshotBank::Slot::B);
+    s.field().reset();
+
+    s.apply_morph_to_live(0.5f);
+    CHECK(s.field().bands[0].gain_db == Approx(0.0f));
+    CHECK(s.field().bands[63].gain_db == Approx(0.0f));
+}
+
+TEST_CASE("M8 plugin-state v2 round-trip preserves snapshot bank") {
+    Spectr a;
+    pulp::state::StateStore store;
+    a.define_parameters(store);
+    a.set_state_store(&store);
+
+    // Populate A with -12 dB ramp, B with +3 dB flat.
+    a.field() = ramp_field(-12.0f, 0.25f);
+    a.capture_snapshot(SnapshotBank::Slot::A);
+    a.field() = make_field(+3.0f);
+    a.capture_snapshot(SnapshotBank::Slot::B);
+    a.snapshots().active = SnapshotBank::Slot::B;
+
+    const auto bytes = a.serialize_plugin_state();
+    REQUIRE_FALSE(bytes.empty());
+
+    Spectr b;
+    pulp::state::StateStore store_b;
+    b.define_parameters(store_b);
+    b.set_state_store(&store_b);
+    REQUIRE(b.deserialize_plugin_state(bytes));
+
+    const auto& A = b.snapshots().a;
+    const auto& B = b.snapshots().b;
+    CHECK(A.populated);
+    CHECK(B.populated);
+    CHECK(A.field.bands[0].gain_db == Approx(-12.0f));
+    CHECK(A.field.bands[63].gain_db == Approx(-12.0f + 63 * 0.25f));
+    CHECK(B.field.bands[0].gain_db == Approx(+3.0f));
+    CHECK(B.field.bands[63].gain_db == Approx(+3.0f));
+    CHECK(b.snapshots().active == SnapshotBank::Slot::B);
+}
+
+TEST_CASE("M8 plugin-state v1 blob loads with an empty snapshot bank") {
+    // Forge a minimal v1 blob (no snapshots member).
+    const std::string v1 =
+        R"({"version":1,"band_gain":[)" +
+        std::string([] {
+            std::string s;
+            for (std::size_t i = 0; i < kMaxBands; ++i) {
+                if (i) s += ",";
+                s += "0.0";
+            }
+            return s;
+        }()) + R"(],"band_mute":[)" +
+        std::string([] {
+            std::string s;
+            for (std::size_t i = 0; i < kMaxBands; ++i) {
+                if (i) s += ",";
+                s += "false";
+            }
+            return s;
+        }()) + R"(],"view_min_hz":20.0,"view_max_hz":20000.0,"layout_index":0,"analyzer_mode":0,"edit_mode":0})";
+
+    Spectr s;
+    pulp::state::StateStore store;
+    s.define_parameters(store);
+    s.set_state_store(&store);
+
+    const std::vector<uint8_t> bytes(v1.begin(), v1.end());
+    REQUIRE(s.deserialize_plugin_state(bytes));
+    CHECK_FALSE(s.snapshots().has(SnapshotBank::Slot::A));
+    CHECK_FALSE(s.snapshots().has(SnapshotBank::Slot::B));
+}


### PR DESCRIPTION
Closes out two build-plan milestones back to back while \`pulp#670\` (WindowHost content-size API) is still in review upstream.

## Milestone 8 — Snapshot A/B + morph

Two-slot snapshot bank for the canonical 64-slot BandField + viewport + layout, with per-band morph interpolation. Flat-parameter A/B rides \`pulp::view::ABCompare\` over StateStore; this adds the band-side complement that ABCompare can't capture on its own.

- \`include/spectr/snapshot.hpp\` + \`src/snapshot.cpp\` — FieldSnapshot, SnapshotBank (A/B + populated bit + active-slot selector), morph_fields (linear lerp on gain_db in dB space, mute follows dominant slot, clamped, aliasing-safe).
- \`Spectr::kMorph\` — new flat StateStore param in [0,1], default 0.
- \`Spectr::snapshots()\`, \`capture_snapshot()\`, \`apply_morph_to_live()\`, \`ab_compare()\` accessors. ABCompare is constructed in \`define_parameters\` once the StateStore reference is live.
- Plugin-state schema bumps to v2 with a \`snapshots\` object holding the full bank. v1 blobs still load cleanly (bank resets to empty); v3+ is rejected.

Exit criteria:
- **A/B toggle is click-level in UI** — API is there; UI hookup is M9.5.
- **Morph is artifact-free at any position** — continuity test asserts no band jumps more than span × Δt at any t.
- **Both survive host session reload** — v2 plugin-state round-trip test asserts it.

## Milestone 9 — Spectr-owned JSON preset format

Per V2 handoff §7: presets persist through a Spectr-owned wrapper rather than PresetManager's default. One file restores the full sound end-to-end.

- \`include/spectr/preset_format.hpp\` + \`src/preset_format.cpp\` — PresetMetadata, PresetLoadError, PresetLoadResult, save/load (string + file variants), describe().
- File format: \`format\` tag, \`schema_version\`, \`plugin_version\`, \`metadata\` (name/author/description/timestamps), \`state.state_store\` (base64 of StateStore::serialize()), \`state.plugin_state\` (inline JSON object from serialize_plugin_state).
- Schema version mismatch is a hard error — no silent downgrade.

Exit criteria:
- **Save/load round-trip matches working state exactly** — asserted across flat params, supplemental state, snapshot bank, and metadata.
- **Older preset schema versions report a clear migration error** — \`SchemaMismatch\` flag plus \`describe()\` message that mentions both \"schema\" and \"migrate\".

## Tests

\`\`\`
100% tests passed, 0 tests failed out of 88
Total Test time (real) = 2.39 sec
\`\`\`

20 new tests across the two milestones:
- 12 M8 tests: morph endpoints/midpoint/continuity/clamp/mute dominance, bank capture/copy/swap, Spectr-level no-op-when-empty / single-populated-wins / mid-morph blend, v2 plugin-state round-trip, v1 legacy compatibility.
- 8 M9 tests: full round-trip (flat + supplemental + snapshots + metadata), schema mismatch, non-Spectr rejection, malformed-JSON doesn't-touch-state, missing state block, corrupt base64, file I/O round-trip, describe() stability.

## Follow-ups (not in this PR)

- **M9.5** — wire the JS editor bridge so the prototype HTML's A/B + morph slider and preset-browser controls drive this.
- **M10** — \`auval\` / \`pluginval\` / \`clap-validator\` passes.
- **M11** — windowed STFT engine upgrade.
- **Task #32** — drop the \`editor_view.cpp\` size-fallback hacks once \`pulp#670\` merges.