### PR TITLE
CI: bump mac target timeout to 3600s

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -36,6 +36,14 @@ test      = "ctest --test-dir build --output-on-failure"
 [targets.mac]
 backend  = "local"
 platform = "macos-arm64"
+# First shipyard run burns ~10-15 min in `configure` because Catch2's
+# FetchContent clones from scratch into a fresh `_deps/` directory.
+# Spectr has no pre-fetch setup stage (unlike pulp's ./setup.sh), so
+# the whole clone happens inside configure itself. Default 1800s is
+# too tight; 3600s gives cold runs enough room and stays well short
+# of the ssh-windows-style hour we use on other projects. Warm runs
+# (after the first successful build) finish in under 2 minutes.
+timeout_secs = 3600
 
 # ── Cloud dispatch (Namespace) ─────────────────────────────────────────────
 # Enables `shipyard cloud run build <branch>` against Namespace-hosted


### PR DESCRIPTION
First \`shipyard ship\` attempt on PR #4 tripped the default 1800s ceiling during the configure stage, still mid-Catch2 FetchContent clone. Spectr has no setup-stage pre-fetch, so the entire dependency clone happens inside configure itself — 1800s is too tight on a cold run.

## Fix

- Mac target \`timeout_secs = 3600\`. Matches what pulp's ssh-windows lane uses for its x64-cross-compile budget. Warm runs finish in ~2 min regardless.

Follow-up filed upstream at [Shipyard #202](https://github.com/danielraffel/Shipyard/issues/202) for per-stage timeouts + configure-progress streaming, so future users can tell a genuinely-hung configure apart from a slow FetchContent. That would let us drop this to something tighter without losing headroom.

## Verification plan

Merge this, then re-run \`shipyard ship\` on a new feature branch (any trivial change). Should now complete configure within ~15 min on a fresh tree and far faster on warm trees.