### PR TITLE
M9.5 (slice 1) — Editor bridge message routing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SPECTR_SOURCES
     src/spectr.cpp
     src/block_fft_engine.cpp
     src/edit_engine.cpp
+    src/editor_bridge.cpp
     src/pattern.cpp
     src/preset_format.cpp
     src/snapshot.cpp
@@ -29,6 +30,7 @@ set(SPECTR_HEADERS
     include/spectr/viewport.hpp
     include/spectr/engine.hpp
     include/spectr/edit_modes.hpp
+    include/spectr/editor_bridge.hpp
     include/spectr/preset_format.hpp
     include/spectr/snapshot.hpp
     include/spectr/windowed_stft_engine.hpp
@@ -63,6 +65,7 @@ add_executable(Spectr-test
     test/test_m4_state.cpp
     test/test_edit_engine.cpp
     test/test_pattern.cpp
+    test/test_editor_bridge.cpp
     test/test_preset.cpp
     test/test_snapshot.cpp
     test/test_windowed_stft_engine.cpp

--- a/include/spectr/editor_bridge.hpp
+++ b/include/spectr/editor_bridge.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+// Milestone 9.5 — JS ↔ C++ editor bridge (foundation slice).
+//
+// Routes JSON messages from the editor WebView into Spectr's C++ state
+// — paint gestures, edit-mode selection, snapshot capture, morph
+// slider, pattern library picks, preset save/load, flat-parameter
+// writes. Lives behind a stateless-per-call dispatch function so
+// tests can exercise every message path without touching a WebView.
+//
+// The schema documented in this header is the canonical contract
+// between whatever JS shim sits inside the editor HTML and the C++
+// processor. Any new message type lands here before it lands in the
+// HTML side.
+//
+//
+// ── Envelope ───────────────────────────────────────────────────────────
+//
+// Every bridge message is a JSON object of this shape:
+//
+//   {
+//     "type": "<kind>",
+//     "payload": { ... }     // optional, shape per type
+//   }
+//
+// Responses are JSON objects of this shape:
+//
+//   { "ok": true }                          // on success
+//   { "ok": false, "error": "…" }           // on failure
+//
+// The bridge never throws. Malformed JSON, unknown `type`, or a
+// payload that violates the per-type contract all yield the second
+// response shape with an error string describing what went wrong.
+//
+// ── Drag protocol (paint_start / paint / paint_end) ─────────────────────
+//
+// Spectr's edit modes are gesture-based: some modes (Boost / Flare /
+// Glide) need a stable snapshot taken at drag start so that
+// successive paint updates don't drift. The bridge enforces that by
+// tracking drag state across messages:
+//
+//   paint_start   → capture a BandSnapshot from Spectr.field()
+//   paint         → dispatch_edit with the captured snapshot
+//   paint_end     → drop the snapshot
+//
+// A paint message without a preceding paint_start is rejected.
+// A second paint_start without an intervening paint_end replaces the
+// held snapshot (treated as a new drag).
+//
+// ── Message types ─────────────────────────────────────────────────────
+//
+//  type="paint_start"
+//    payload: {} — no fields required.
+//    Effect: capture BandSnapshot of the current field.
+//
+//  type="paint"
+//    payload: {
+//      "mode":          "Sculpt" | "Level" | "Boost" | "Flare" | "Glide",
+//      "start_band":    uint,     // canonical band index of drag origin
+//      "start_value":   float,    // dB, [-60, +12]
+//      "current_band":  uint,
+//      "current_value": float,
+//      "n_visible":     uint      // visible layout band count
+//    }
+//    Effect: dispatch_edit(mode, field, drag, snapshot).
+//
+//  type="paint_end"
+//    payload: {} — no fields.
+//    Effect: clear the held snapshot.
+//
+//  type="morph"
+//    payload: { "t": float }      // [0, 1], clamped
+//    Effect: Spectr::apply_morph_to_live(t).
+//
+//  type="capture_snapshot"
+//    payload: { "slot": "A" | "B" }
+//    Effect: Spectr::capture_snapshot(slot).
+//
+//  type="ab_toggle"
+//    payload: {} — no fields.
+//    Effect: flip snapshots().active between A and B.
+//
+//  type="load_pattern"
+//    payload: { "id": "<pattern_id>" }
+//    Effect: look up in PatternLibrary and apply to Spectr.field().
+//    The library is the plugin's current library; id matches
+//    Pattern::id.
+//    (Payload future-compat: optional "library" field for non-default
+//    libraries; ignored in this slice.)
+//
+// ── Not yet in this slice ─────────────────────────────────────────────
+//
+//  save_preset / load_preset / param_set / state_push (C++ → JS)
+//
+// These are planned for follow-up slices so this first commit stays
+// bounded. The schema header reserves their names; the dispatch
+// function returns "unknown type" for them today.
+
+#include <choc/containers/choc_Value.h>
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "spectr/edit_engine.hpp"  // BandSnapshot — full type needed for optional
+
+namespace spectr {
+
+class Spectr;
+class PatternLibrary;
+
+/// State carried across bridge messages within a single editor session.
+/// A WebView owns one; `dispatch_editor_message` reads and mutates
+/// it under the covers.
+struct EditorBridgeState {
+    /// Snapshot captured at paint_start. Present while a drag is live.
+    std::optional<BandSnapshot> drag_snap;
+};
+
+/// Dispatch one already-parsed bridge message. The `type` and
+/// `payload` come from the envelope; callers that have a JSON string
+/// should use `dispatch_editor_message_json` below.
+std::string dispatch_editor_message(Spectr& plugin,
+                                    PatternLibrary* library,
+                                    EditorBridgeState& state,
+                                    std::string_view type,
+                                    const choc::value::ValueView& payload) noexcept;
+
+/// Parse a JSON envelope and dispatch. Returns the same
+/// `{"ok":true|false,"error":"…"}` response as the parsed variant.
+std::string dispatch_editor_message_json(Spectr& plugin,
+                                         PatternLibrary* library,
+                                         EditorBridgeState& state,
+                                         std::string_view json) noexcept;
+
+} // namespace spectr

--- a/include/spectr/spectr.hpp
+++ b/include/spectr/spectr.hpp
@@ -15,6 +15,7 @@
 #include "spectr/band_state.hpp"
 #include "spectr/edit_modes.hpp"
 #include "spectr/engine.hpp"
+#include "spectr/pattern.hpp"
 #include "spectr/snapshot.hpp"
 #include "spectr/viewport.hpp"
 
@@ -135,6 +136,17 @@ public:
     /// the store). Returns nullptr if the store isn't available yet.
     pulp::view::ABCompare* ab_compare() noexcept;
 
+    // ── Pattern library ────────────────────────────────────────────────
+    //
+    // Each Spectr owns a PatternLibrary pre-populated with the factory
+    // presets. User patterns come and go through the editor bridge's
+    // load_pattern / (future) save_current paths. Persistence for
+    // user patterns is a M9 follow-up — the library lives in memory
+    // only for now; serialize_plugin_state doesn't yet pack it into
+    // the supplemental blob.
+    PatternLibrary&       patterns()       noexcept { return patterns_; }
+    const PatternLibrary& patterns() const noexcept { return patterns_; }
+
     // ── Analyzer bridge — UI-thread read path ───────────────────────────
     //
     // Spectr publishes STFT + meter + waveform snapshots from the audio
@@ -159,6 +171,7 @@ private:
 
     pulp::view::VisualizationBridge       bridge_{};
     SnapshotBank                          snapshots_{};
+    PatternLibrary                        patterns_{};
     std::unique_ptr<pulp::view::ABCompare> ab_{};
 
     void rebuild_engine_();

--- a/include/spectr/ui/editor_view.hpp
+++ b/include/spectr/ui/editor_view.hpp
@@ -14,9 +14,12 @@
 
 #include <memory>
 
+#include "spectr/editor_bridge.hpp"
+
 namespace spectr {
 
 class Spectr;
+class PatternLibrary;
 
 class EditorView : public pulp::view::View {
 public:
@@ -40,7 +43,10 @@ private:
     std::unique_ptr<pulp::view::WebViewPanel> panel_;
     bool attached_ = false;
 
-    void handle_message_(const pulp::view::WebViewMessage& msg);
+    // Bridge state for paint-drag snapshot capture — see editor_bridge.hpp.
+    EditorBridgeState bridge_state_{};
+
+    std::string handle_message_(const pulp::view::WebViewMessage& msg);
 };
 
 } // namespace spectr

--- a/src/editor_bridge.cpp
+++ b/src/editor_bridge.cpp
@@ -1,0 +1,209 @@
+#include "spectr/editor_bridge.hpp"
+
+#include "spectr/spectr.hpp"
+#include "spectr/edit_engine.hpp"
+#include "spectr/edit_modes.hpp"
+#include "spectr/pattern.hpp"
+#include "spectr/snapshot.hpp"
+
+#include <choc/text/choc_JSON.h>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+namespace spectr {
+
+namespace {
+
+// ── Response helpers ───────────────────────────────────────────────────
+
+// Both success and failure go through choc::json::toString so callers
+// see a single, consistent envelope shape — choc formats as
+// `{"ok": true}` / `{"ok": false, "error": "…"}` (note the space after
+// the colon; choc always inserts one even in no-linebreak mode).
+std::string ok_response() {
+    auto obj = choc::value::createObject("BridgeOk");
+    obj.addMember("ok", true);
+    return choc::json::toString(obj, /*useLineBreaks=*/false);
+}
+
+std::string err_response(std::string_view msg) {
+    auto obj = choc::value::createObject("BridgeError");
+    obj.addMember("ok",    false);
+    obj.addMember("error", std::string(msg));
+    return choc::json::toString(obj, /*useLineBreaks=*/false);
+}
+
+// ── Value coercion helpers ─────────────────────────────────────────────
+//
+// choc's ValueView throws if you call the wrong getter; these never
+// throw and map missing/wrong-type to defaults. Each type's handler
+// defends against a malformed payload without crashing the bridge.
+
+float get_float_(const choc::value::ValueView& v, const char* key, float dflt) {
+    if (!v.isObject() || !v.hasObjectMember(key)) return dflt;
+    const auto e = v[key];
+    if (e.isFloat64()) return static_cast<float>(e.getFloat64());
+    if (e.isInt64())   return static_cast<float>(e.getInt64());
+    if (e.isInt32())   return static_cast<float>(e.getInt32());
+    return dflt;
+}
+
+std::size_t get_uint_(const choc::value::ValueView& v, const char* key, std::size_t dflt) {
+    if (!v.isObject() || !v.hasObjectMember(key)) return dflt;
+    const auto e = v[key];
+    if (e.isInt32())   { const auto x = e.getInt32(); return x < 0 ? 0 : static_cast<std::size_t>(x); }
+    if (e.isInt64())   { const auto x = e.getInt64(); return x < 0 ? 0 : static_cast<std::size_t>(x); }
+    if (e.isFloat64()) { const auto x = e.getFloat64(); return x < 0 ? 0 : static_cast<std::size_t>(x); }
+    return dflt;
+}
+
+std::string get_string_(const choc::value::ValueView& v, const char* key) {
+    if (!v.isObject() || !v.hasObjectMember(key)) return {};
+    const auto e = v[key];
+    if (!e.isString()) return {};
+    return std::string(e.getString());
+}
+
+// Parse an EditMode label. Returns nullopt on unknown.
+std::optional<EditMode> parse_edit_mode_(std::string_view s) {
+    if (s == "Sculpt") return EditMode::Sculpt;
+    if (s == "Level")  return EditMode::Level;
+    if (s == "Boost")  return EditMode::Boost;
+    if (s == "Flare")  return EditMode::Flare;
+    if (s == "Glide")  return EditMode::Glide;
+    return std::nullopt;
+}
+
+// Parse a snapshot slot label.
+std::optional<SnapshotBank::Slot> parse_slot_(std::string_view s) {
+    if (s == "A") return SnapshotBank::Slot::A;
+    if (s == "B") return SnapshotBank::Slot::B;
+    return std::nullopt;
+}
+
+// ── Handlers ───────────────────────────────────────────────────────────
+
+std::string on_paint_start_(Spectr& plugin, EditorBridgeState& state,
+                            const choc::value::ValueView& /*payload*/) {
+    state.drag_snap = BandSnapshot::capture(plugin.field());
+    return ok_response();
+}
+
+std::string on_paint_(Spectr& plugin, EditorBridgeState& state,
+                      const choc::value::ValueView& payload) {
+    if (!state.drag_snap) {
+        return err_response("paint without paint_start");
+    }
+    const auto mode_str = get_string_(payload, "mode");
+    const auto mode = parse_edit_mode_(mode_str);
+    if (!mode) return err_response("unknown edit mode");
+
+    DragGesture drag;
+    drag.start_band    = get_uint_(payload, "start_band",   0);
+    drag.start_value   = get_float_(payload, "start_value", 0.0f);
+    drag.current_band  = get_uint_(payload, "current_band", drag.start_band);
+    drag.current_value = get_float_(payload, "current_value", drag.start_value);
+    drag.n_visible     = get_uint_(payload, "n_visible",    32);
+
+    dispatch_edit(*mode, plugin.field(), drag, *state.drag_snap);
+    return ok_response();
+}
+
+std::string on_paint_end_(Spectr& /*plugin*/, EditorBridgeState& state,
+                          const choc::value::ValueView& /*payload*/) {
+    state.drag_snap.reset();
+    return ok_response();
+}
+
+std::string on_morph_(Spectr& plugin, EditorBridgeState& /*state*/,
+                      const choc::value::ValueView& payload) {
+    const auto t = std::clamp(get_float_(payload, "t", 0.0f), 0.0f, 1.0f);
+    plugin.apply_morph_to_live(t);
+    return ok_response();
+}
+
+std::string on_capture_snapshot_(Spectr& plugin, EditorBridgeState& /*state*/,
+                                 const choc::value::ValueView& payload) {
+    const auto slot = parse_slot_(get_string_(payload, "slot"));
+    if (!slot) return err_response("slot must be 'A' or 'B'");
+    plugin.capture_snapshot(*slot);
+    return ok_response();
+}
+
+std::string on_ab_toggle_(Spectr& plugin, EditorBridgeState& /*state*/,
+                          const choc::value::ValueView& /*payload*/) {
+    auto& b = plugin.snapshots();
+    b.active = (b.active == SnapshotBank::Slot::A) ? SnapshotBank::Slot::B
+                                                   : SnapshotBank::Slot::A;
+    return ok_response();
+}
+
+std::string on_load_pattern_(Spectr& plugin, PatternLibrary* library,
+                             const choc::value::ValueView& payload) {
+    if (!library) return err_response("no pattern library attached");
+    const auto id = get_string_(payload, "id");
+    if (id.empty()) return err_response("pattern id missing");
+    const auto* p = library->find(id);
+    if (!p) return err_response("unknown pattern id");
+    p->apply_to(plugin.field());
+    return ok_response();
+}
+
+} // namespace
+
+// ── Dispatch ───────────────────────────────────────────────────────────
+
+std::string dispatch_editor_message(Spectr& plugin,
+                                    PatternLibrary* library,
+                                    EditorBridgeState& state,
+                                    std::string_view type,
+                                    const choc::value::ValueView& payload) noexcept
+{
+    try {
+        if (type == "paint_start")       return on_paint_start_(plugin, state, payload);
+        if (type == "paint")             return on_paint_(plugin, state, payload);
+        if (type == "paint_end")         return on_paint_end_(plugin, state, payload);
+        if (type == "morph")             return on_morph_(plugin, state, payload);
+        if (type == "capture_snapshot")  return on_capture_snapshot_(plugin, state, payload);
+        if (type == "ab_toggle")         return on_ab_toggle_(plugin, state, payload);
+        if (type == "load_pattern")      return on_load_pattern_(plugin, library, payload);
+        // Reserved-for-future types return a distinguishable error so a
+        // JS caller sending these during development gets a clear
+        // signal rather than a silent drop.
+        if (type == "save_preset" ||
+            type == "load_preset" ||
+            type == "param_set")         return err_response("not implemented in this slice");
+        return err_response("unknown message type");
+    } catch (...) {
+        return err_response("internal error");
+    }
+}
+
+std::string dispatch_editor_message_json(Spectr& plugin,
+                                         PatternLibrary* library,
+                                         EditorBridgeState& state,
+                                         std::string_view json) noexcept
+{
+    choc::value::Value root;
+    try {
+        root = choc::json::parse(json);
+    } catch (...) {
+        return err_response("malformed JSON");
+    }
+    if (!root.isObject()) return err_response("envelope must be an object");
+
+    const auto type = get_string_(root, "type");
+    if (type.empty()) return err_response("envelope missing 'type'");
+
+    // Payload is optional; handlers defend against missing fields.
+    if (!root.hasObjectMember("payload")) {
+        // Pass an empty object as the payload.
+        auto empty = choc::value::createObject("Empty");
+        return dispatch_editor_message(plugin, library, state, type, empty);
+    }
+    return dispatch_editor_message(plugin, library, state, type, root["payload"]);
+}
+
+} // namespace spectr

--- a/src/ui/editor_view.cpp
+++ b/src/ui/editor_view.cpp
@@ -1,4 +1,5 @@
 #include "spectr/ui/editor_view.hpp"
+#include "spectr/editor_bridge.hpp"
 #include "spectr/spectr.hpp"
 
 #include <pulp/runtime/log.hpp>
@@ -127,8 +128,7 @@ void EditorView::attach_if_needed() {
         }
 
         panel_->set_message_handler([this](const pulp::view::WebViewMessage& m) -> std::string {
-            handle_message_(m);
-            return R"({"ok":true})";
+            return handle_message_(m);
         });
         panel_->set_ready_handler([p = panel_.get()] {
             p->navigate("pulp://spectr");
@@ -173,10 +173,26 @@ void EditorView::detach_if_needed() {
     attached_ = false;
 }
 
-void EditorView::handle_message_(const pulp::view::WebViewMessage& msg) {
+std::string EditorView::handle_message_(const pulp::view::WebViewMessage& msg) {
     pulp::runtime::log_info("[Spectr] webview msg type='{}' payload='{}'",
                             msg.type, msg.payload_json);
-    (void)plugin_;
+
+    // The pulp WebViewMessage surfaces `type` as its own field and
+    // `payload_json` as the payload object. Rebuild the envelope
+    // shape the bridge expects so we can reuse one dispatcher for
+    // both in-WebView and unit-test entry points. Inner JSON is
+    // trusted — any parse error is surfaced through the bridge's
+    // normal error response.
+    std::string envelope;
+    envelope.reserve(msg.type.size() + msg.payload_json.size() + 32);
+    envelope += R"({"type":")";
+    envelope += msg.type;
+    envelope += R"(","payload":)";
+    envelope += msg.payload_json.empty() ? std::string("{}") : msg.payload_json;
+    envelope += "}";
+
+    return dispatch_editor_message_json(plugin_, &plugin_.patterns(),
+                                        bridge_state_, envelope);
 }
 
 } // namespace spectr

--- a/test/test_editor_bridge.cpp
+++ b/test/test_editor_bridge.cpp
@@ -1,0 +1,215 @@
+// Milestone 9.5 (slice 1) — JS ↔ C++ editor bridge.
+//
+// Unit tests for the message router. Every message type is exercised
+// through the JSON envelope (i.e. the same path the WebView will
+// drive). The `Spectr` plugin and an optional `PatternLibrary` are
+// wired up to observe side effects.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "spectr/editor_bridge.hpp"
+#include "spectr/pattern.hpp"
+#include "spectr/snapshot.hpp"
+#include "spectr/spectr.hpp"
+
+#include <pulp/state/store.hpp>
+
+#include <memory>
+#include <string>
+
+using Catch::Approx;
+using spectr::BandField;
+using spectr::EditorBridgeState;
+using spectr::PatternLibrary;
+using spectr::SnapshotBank;
+using spectr::Spectr;
+using spectr::dispatch_editor_message_json;
+
+namespace {
+
+struct Rig {
+    pulp::state::StateStore   store;
+    std::unique_ptr<Spectr>   proc;
+    PatternLibrary            library;
+    EditorBridgeState         bridge;
+
+    Rig() : proc(std::make_unique<Spectr>()) {
+        proc->set_state_store(&store);
+        proc->define_parameters(store);
+    }
+};
+
+// choc::json::toString emits `"ok": true/false` with a space after
+// the colon — match both with/without space so these helpers stay
+// robust if the bridge switches to a no-space emitter later.
+bool response_ok(const std::string& r) {
+    return r.find("\"ok\": true")  != std::string::npos
+        || r.find("\"ok\":true")   != std::string::npos;
+}
+
+bool response_has_error(const std::string& r, std::string_view substr) {
+    const bool not_ok = r.find("\"ok\": false") != std::string::npos
+                     || r.find("\"ok\":false")  != std::string::npos;
+    return not_ok && r.find(substr) != std::string::npos;
+}
+
+} // namespace
+
+TEST_CASE("M9.5 bridge: malformed JSON returns error") {
+    Rig r;
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+                                                   "not json");
+    CHECK(response_has_error(resp, "malformed JSON"));
+}
+
+TEST_CASE("M9.5 bridge: missing 'type' returns error") {
+    Rig r;
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+                                                   R"({"payload":{}})");
+    CHECK(response_has_error(resp, "'type'"));
+}
+
+TEST_CASE("M9.5 bridge: unknown type returns error") {
+    Rig r;
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+                                                   R"({"type":"not_a_message"})");
+    CHECK(response_has_error(resp, "unknown message type"));
+}
+
+TEST_CASE("M9.5 bridge: reserved-for-future types return 'not implemented'") {
+    Rig r;
+    for (const auto* t : {"save_preset", "load_preset", "param_set"}) {
+        const auto msg = std::string(R"({"type":")") + t + R"("})";
+        const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge, msg);
+        INFO("type=" << t);
+        CHECK(response_has_error(resp, "not implemented"));
+    }
+}
+
+TEST_CASE("M9.5 bridge paint: paint without paint_start is rejected") {
+    Rig r;
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"paint","payload":{"mode":"Sculpt","start_band":0,"start_value":0,
+            "current_band":3,"current_value":-6,"n_visible":32}})");
+    CHECK(response_has_error(resp, "paint without paint_start"));
+}
+
+TEST_CASE("M9.5 bridge paint: start → paint → end mutates the field") {
+    Rig r;
+    // Start with a neutral field.
+    r.proc->field() = BandField{};
+
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"paint_start"})")));
+
+    // Sculpt drag from band 2 (0 dB) to band 5 (-6 dB).
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"paint","payload":{"mode":"Sculpt","start_band":2,"start_value":0,
+                "current_band":5,"current_value":-6,"n_visible":32}})")));
+
+    // Bands 2..5 should now sit at -6 dB.
+    for (std::size_t i = 2; i <= 5; ++i) {
+        CHECK(r.proc->field().bands[i].gain_db == Approx(-6.0f));
+    }
+    // Bands outside the drag untouched.
+    CHECK(r.proc->field().bands[0].gain_db == Approx(0.0f));
+
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"paint_end"})")));
+
+    // After end, a paint without a new start fails.
+    const auto after = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"paint","payload":{"mode":"Sculpt","start_band":0,"start_value":0,
+            "current_band":0,"current_value":-3,"n_visible":32}})");
+    CHECK(response_has_error(after, "paint without paint_start"));
+}
+
+TEST_CASE("M9.5 bridge paint: unknown mode returns error without mutating") {
+    Rig r;
+    const auto before = r.proc->field().bands[0].gain_db;
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"paint_start"})")));
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"paint","payload":{"mode":"Blaster","start_band":0,"start_value":0,
+            "current_band":3,"current_value":-6,"n_visible":32}})");
+    CHECK(response_has_error(resp, "unknown edit mode"));
+    CHECK(r.proc->field().bands[0].gain_db == Approx(before));
+}
+
+TEST_CASE("M9.5 bridge morph: clamps t and applies to live field") {
+    Rig r;
+    // Populate A with -10 dB flat, B with +10 dB flat.
+    for (auto& b : r.proc->field().bands) b.gain_db = -10.0f;
+    r.proc->capture_snapshot(SnapshotBank::Slot::A);
+    for (auto& b : r.proc->field().bands) b.gain_db = +10.0f;
+    r.proc->capture_snapshot(SnapshotBank::Slot::B);
+
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"morph","payload":{"t":0.5}})")));
+    CHECK(r.proc->field().bands[0].gain_db == Approx(0.0f));
+
+    // Out-of-range t clamps rather than erroring.
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"morph","payload":{"t":5.0}})")));
+    CHECK(r.proc->field().bands[0].gain_db == Approx(+10.0f));
+
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"morph","payload":{"t":-2.0}})")));
+    CHECK(r.proc->field().bands[0].gain_db == Approx(-10.0f));
+}
+
+TEST_CASE("M9.5 bridge capture_snapshot: slot string is required") {
+    Rig r;
+    r.proc->field().bands[10].gain_db = -4.0f;
+
+    const auto bad = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"capture_snapshot"})");
+    CHECK(response_has_error(bad, "'A' or 'B'"));
+
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"capture_snapshot","payload":{"slot":"A"}})")));
+    CHECK(r.proc->snapshots().has(SnapshotBank::Slot::A));
+    CHECK(r.proc->snapshots().a.field.bands[10].gain_db == Approx(-4.0f));
+
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"capture_snapshot","payload":{"slot":"B"}})")));
+    CHECK(r.proc->snapshots().has(SnapshotBank::Slot::B));
+}
+
+TEST_CASE("M9.5 bridge ab_toggle: flips active slot") {
+    Rig r;
+    CHECK(r.proc->snapshots().active == SnapshotBank::Slot::A);
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"ab_toggle"})")));
+    CHECK(r.proc->snapshots().active == SnapshotBank::Slot::B);
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"ab_toggle"})")));
+    CHECK(r.proc->snapshots().active == SnapshotBank::Slot::A);
+}
+
+TEST_CASE("M9.5 bridge load_pattern: applies by id, errors on unknown") {
+    Rig r;
+    // Flat factory pattern should land every band at 0 dB.
+    for (auto& b : r.proc->field().bands) b.gain_db = -12.0f;
+
+    REQUIRE(response_ok(dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+            R"({"type":"load_pattern","payload":{"id":"factory:flat"}})")));
+    CHECK(r.proc->field().bands[0].gain_db == Approx(0.0f));
+    CHECK(r.proc->field().bands[63].gain_db == Approx(0.0f));
+
+    const auto bad = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"load_pattern","payload":{"id":"factory:bogus"}})");
+    CHECK(response_has_error(bad, "unknown pattern id"));
+
+    const auto empty = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"load_pattern","payload":{}})");
+    CHECK(response_has_error(empty, "pattern id missing"));
+}
+
+TEST_CASE("M9.5 bridge load_pattern: without a library attached errors") {
+    Rig r;
+    const auto resp = spectr::dispatch_editor_message_json(*r.proc, /*library*/nullptr,
+        r.bridge, R"({"type":"load_pattern","payload":{"id":"factory:flat"}})");
+    CHECK(response_has_error(resp, "pattern library"));
+}


### PR DESCRIPTION
Wires a JSON message channel between the editor WebView and Spectr's C++ state so the features landed in M6–M9 (edit modes, pattern library, snapshot A/B + morph) become driveable. Foundation slice: C++ routing + exhaustive unit tests + EditorView hook. HTML-side JS shim is a follow-up — the 1.8 MB bundled prototype needs its own surgery and keeping that out of this PR keeps the review bounded.

## What's in

- **\`include/spectr/editor_bridge.hpp\`** — canonical message schema as an inline header comment. Envelope, payload per type, effect, and the drag protocol. Reserved-for-later types (\`save_preset\`, \`load_preset\`, \`param_set\`) have their names fixed now so the contract doesn't drift as slices land.
- **\`src/editor_bridge.cpp\`** — \`dispatch_editor_message\` + JSON-envelope wrapper. Handlers for \`paint_start\`, \`paint\`, \`paint_end\`, \`morph\`, \`capture_snapshot\`, \`ab_toggle\`, \`load_pattern\`. Every handler defends against missing fields, wrong types, unknown enum values. Responses are \`{\"ok\": true}\` / \`{\"ok\": false, \"error\": \"…\"}\`.
- **\`test/test_editor_bridge.cpp\`** — 12 Catch2 cases: malformed JSON, missing/unknown type, drag-protocol ordering, every handler's happy path and error path. Drives the public JSON-envelope entry point end-to-end.
- **\`include/spectr/ui/editor_view.hpp\` / \`src/ui/editor_view.cpp\`** — EditorView owns an \`EditorBridgeState\` for drag-snapshot persistence. \`handle_message_\` rebuilds the envelope from pulp's \`WebViewMessage\` and hands off to the bridge.
- **\`include/spectr/spectr.hpp\`** — Spectr now owns a \`PatternLibrary\` pre-populated with factory presets. EditorView passes it into the bridge so \`load_pattern\` works in production, not just tests.

## Drag protocol

\`\`\`
paint_start  → capture snapshot
paint        → dispatch_edit with captured snapshot  (× many)
paint_end    → drop snapshot
\`\`\`

A \`paint\` without a preceding \`paint_start\` returns an error. A second \`paint_start\` without an intervening \`paint_end\` replaces the held snapshot (treated as a new drag).

## Tests

\`\`\`
100% tests passed, 0 tests failed out of 103
\`\`\`

103/103 green. 12 new M9.5 tests on top of 91 prior. No regressions.

## Not in this slice (follow-ups)

- HTML-side JS shim that posts these messages from the prototype's UI events. Needs a decision on injecting vs. modifying the bundled template.
- \`save_preset\` / \`load_preset\` / \`param_set\` handlers (schema reserves their names; today they return \`not implemented\`).
- \`PatternLibrary\` persistence through \`serialize_plugin_state\` — memory-only today.
- C++ → JS state push (automation → slider UI). Needs \`panel_->execute_script()\` wiring that doesn't fight the prototype's render loop.