### PR TITLE
chore: bump Shipyard pin v0.29.0 → v0.42.0

### DIFF
--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -21,10 +21,19 @@
 # the cumulative release-note history.
 
 [shipyard]
-# v0.29.0 — tracks pulp's pin as of 2026-04-23. See pulp's
-# tools/shipyard.toml for the cumulative release-note history of each
-# version on the v0.2x line.
-version = "v0.29.0"
+# v0.42.0 — tracks pulp's pin. Jump from v0.29.0 covers the
+# notarization-preserve install fix (v0.36.0, Shipyard #203) that
+# ends the silent-no-op / SIGKILL failure mode this repo hit on
+# 2026-04-23: the pre-v0.36 install.sh ad-hoc-resigned over the
+# Developer-ID signature, and Gatekeeper eventually killed the
+# binary after a background-scan window, which is exactly what
+# happened when `shipyard ship` on Spectr PR #8 degraded to exit 137
+# with zero output. v0.41.0 adds a rich-bundle doctor check
+# (Shipyard #181) and v0.42.0 adds a Gatekeeper / quarantine /
+# codesign doctor check (Shipyard #216) so a future recurrence
+# surfaces with a named error instead of silent binary death.
+# See pulp's tools/shipyard.toml for the full per-release history.
+version = "v0.42.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Tracks pulp's parallel Shipyard pin bump. Jumps 13 minor versions to pull in the full chain of fixes Shipyard shipped since v0.29.

## Why

During last night's session, \`shipyard ship\` on Spectr PR #8 degraded to exit 137 with zero output — same symptom a fresh install of the **pre-v0.36** binary also exhibits. Root cause per [Shipyard #216](https://github.com/danielraffel/Shipyard/issues/216): the pre-v0.36 \`install.sh\` ad-hoc-resigned over the Developer-ID signature, and Gatekeeper killed the binary after a background-scan window.

Key fixes this bump unlocks:

- **v0.36.0 / [Shipyard #203](https://github.com/danielraffel/Shipyard/pull/203)** — install.sh notarization-preserve. Verified working on this bump: installer log reported \`Detected Developer-ID-signed binary (95CX6P84C4); preserving notarization.\`
- **v0.41.0 / Shipyard #181** — rich-bundle \`shipyard doctor\` check.
- **v0.42.0 / [Shipyard #216](https://github.com/danielraffel/Shipyard/issues/216)** — Gatekeeper/quarantine/codesign \`shipyard doctor\` check. Future recurrence of the SIGKILL pattern will surface with a named error instead of exit-137 silence.

## Mechanics performed (per tools/shipyard.toml comment)

- [x] Edit \`version\` in \`tools/shipyard.toml\` to \`v0.42.0\`.
- [x] Run \`./tools/install-shipyard.sh\` — completed cleanly, notarization preserved.
- [x] \`codesign -dvv\` confirms Developer ID Daniel Raffel (95CX6P84C4), signed with runtime hardening, recent timestamp.
- [ ] \`shipyard --version\` — exits 137 in *this* shell session. See caveat below. Verified working in the user's normal shell is pending before merge.
- [ ] \`shipyard doctor\` — same session caveat.
- [ ] \`shipyard run\` on this branch — blocked on the same.

## Caveat + verification pending

The agent shell that composed this PR can't exercise \`shipyard --version\` end-to-end — exit 137 persists even with the sandbox explicitly disabled. The binary is correctly signed (\`codesign --verify\`: valid on disk + satisfies Designated Requirement), has no \`com.apple.quarantine\` xattr (only informational \`com.apple.provenance\`), and the crash reports from earlier in the session show \`termination: CODESIGNING / Taskgated Invalid Signature\`.

That's likely due to shared session state (stale daemon holding an old binary inode, or cached taskgated verdict) that this session shouldn't thrash — [Shipyard #216](https://github.com/danielraffel/Shipyard/issues/216#issuecomment-4310958373) now has the fresh repro data.

**Merge checklist for the reviewer** (to run in a fresh shell):

- [ ] \`shipyard --version\` prints \`v0.42.0\`
- [ ] \`shipyard doctor\` → Core green, \`rich-bundle\` and \`macos-gatekeeper\` rows present and ok
- [ ] \`shipyard run\` on this branch succeeds end-to-end

## Out of scope

- No changes to \`install-shipyard.sh\` itself (it's Shipyard's source of truth; flagged in the commit body in case the reviewer spots anything stale).
- Pulp's pin bump is owned by a sibling session.
- No README/CONTRIBUTING sweep — checked for Shipyard-version-pinned command references, nothing found.