### PR TITLE
chore: bump Shipyard pin v0.29.0 → v0.43.0

### DIFF
--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -21,10 +21,19 @@
 # the cumulative release-note history.
 
 [shipyard]
-# v0.29.0 — tracks pulp's pin as of 2026-04-23. See pulp's
-# tools/shipyard.toml for the cumulative release-note history of each
-# version on the v0.2x line.
-version = "v0.29.0"
+# v0.43.0 — tracks pulp's pin. Jump from v0.29.0 covers the
+# notarization-preserve install fix (v0.36.0, Shipyard #203) that
+# ends the silent-no-op / SIGKILL failure mode this repo hit on
+# 2026-04-23: the pre-v0.36 install.sh ad-hoc-resigned over the
+# Developer-ID signature, and Gatekeeper eventually killed the
+# binary after a background-scan window, which is what happened when
+# `shipyard ship` on Spectr PR #8 degraded to exit 137 with zero
+# output. v0.41.0 adds a rich-bundle doctor check (Shipyard #181)
+# and v0.43.0 adds a Gatekeeper / quarantine / codesign doctor
+# check (Shipyard #216) so a future recurrence surfaces with a
+# named error instead of silent binary death.
+# See pulp's tools/shipyard.toml for the full per-release history.
+version = "v0.43.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Tracks pulp's parallel Shipyard pin bump. Jump from v0.29 → v0.43 pulls in the full chain of fixes Shipyard shipped after the 2026-04-23 Spectr SIGKILL incident on PR #8.

## Why

- **v0.36.0 / [Shipyard #203](https://github.com/danielraffel/Shipyard/pull/203)** — install.sh notarization-preserve. Pre-v0.36 \`install.sh\` ad-hoc-resigned over the Developer-ID signature; Gatekeeper killed the binary after its background-scan window, producing the exit-137-silence pattern we hit.
- **v0.41.0 / Shipyard #181** — rich-bundle \`shipyard doctor\` check.
- **v0.43.0 / [Shipyard #216](https://github.com/danielraffel/Shipyard/issues/216)** — Gatekeeper / quarantine / codesign \`shipyard doctor\` check. v0.43.0's \`install.sh\` also adds a post-install \`shipyard --version\` smoke test that surfaces the #216 failure mode with a named error (pointing at [Shipyard #219](https://github.com/danielraffel/Shipyard/issues/219) for the .dmg-stapling fix) instead of silent binary death.

## Install verification on this host

\`\`\`
$ ./tools/install-shipyard.sh
→ Installing Shipyard v0.43.0 via upstream install.sh
Detected Developer-ID-signed binary (95CX6P84C4); preserving notarization.
Installed shipyard to /Users/danielraffel/.local/bin/shipyard

ERROR: shipyard was installed but failed its post-install smoke test.
  - taskgated rejected the binary. ... see Shipyard #219 for status on the
    .dmg-stapling fix.

$ codesign -dvv ~/.local/bin/shipyard
Authority=Developer ID Application: Daniel Raffel (95CX6P84C4)
Timestamp=Apr 23, 2026 at 10:31:32 PM
Runtime Version=15.5.0
\`\`\`

## Test plan

- [x] \`./tools/install-shipyard.sh\` → v0.43.0 lands at \`~/.local/bin/shipyard\` with preserved Developer-ID signature.
- [ ] \`shipyard --version\` reports v0.43.0 — **blocked on Shipyard #219** (.dmg stapling). v0.43.0's new post-install smoke test explicitly names this as a known issue with a tracked fix.
- [ ] \`shipyard doctor\` shows \`rich-bundle\` + \`macos-gatekeeper\` rows — same block.
- [ ] \`shipyard run\` on this branch → same block.

Verification of the binary itself (not the file change) can finish once #219 lands. The file change here stands independently because every future consumer of this repo now gets the loud-on-failure smoke test instead of the silent-no-op + picks up the new doctor checks whenever they do run.

## Lockstep docs

No list enumerated in Spectr's \`tools/shipyard.toml\` — checked README + CONTRIBUTING for Shipyard-version-pinned command references, nothing found.

## Out of scope

- No changes to \`install-shipyard.sh\` (Shipyard's source of truth).
- Pulp's pin bump is owned by a sibling session.

Supersedes the closed PR #9 (v0.42.0 bump — superseded because v0.43 was published before that PR could merge).