### PR TITLE
M9.5 (slice 2) — preset / param bridge + PatternLibrary persistence

### DIFF
--- a/include/spectr/editor_bridge.hpp
+++ b/include/spectr/editor_bridge.hpp
@@ -88,13 +88,43 @@
 //    (Payload future-compat: optional "library" field for non-default
 //    libraries; ignored in this slice.)
 //
+//  type="save_preset"
+//    payload: {
+//      "name":        string,        // optional; all metadata optional
+//      "author":      string,
+//      "description": string,
+//      "created_at":  string,        // ISO-8601
+//      "modified_at": string
+//    }
+//    Effect: build a preset JSON string from the current processor
+//    state + the provided metadata and return it in the response:
+//      {"ok": true, "preset_json": "<serialized>"}
+//    The bridge does not touch the filesystem — JS is responsible
+//    for prompting the user and writing the blob wherever the host
+//    OS allows. Mirrors how the prototype's pattern-manager modal
+//    handles export.
+//
+//  type="load_preset"
+//    payload: { "preset_json": "<serialized>" }
+//    Effect: parse the JSON and apply to StateStore + plugin state.
+//    Response includes the metadata from the preset on success:
+//      {"ok": true, "name": "…", "author": "…", … }
+//    On schema mismatch returns {"ok": false, "error": "…"} with
+//    a message describing the mismatch (see PresetLoadError).
+//
+//  type="param_set"
+//    payload: { "id": int, "value": float }
+//    Effect: StateStore::set_value(id, value). No range checking —
+//    the StateStore enforces the parameter's declared range.
+//    Hosts automate through their own channels; this is for
+//    editor-driven changes that should loop through the StateStore
+//    (so undo groups + snapshot capture see the write).
+//
 // ── Not yet in this slice ─────────────────────────────────────────────
 //
-//  save_preset / load_preset / param_set / state_push (C++ → JS)
-//
-// These are planned for follow-up slices so this first commit stays
-// bounded. The schema header reserves their names; the dispatch
-// function returns "unknown type" for them today.
+//  state_push (C++ → JS, for automation-to-UI sync). Requires
+//  panel_->execute_script() wiring that doesn't fight the prototype's
+//  render loop. Planned for M9.5 slice 4.
 
 #include <choc/containers/choc_Value.h>
 

--- a/src/editor_bridge.cpp
+++ b/src/editor_bridge.cpp
@@ -4,7 +4,10 @@
 #include "spectr/edit_engine.hpp"
 #include "spectr/edit_modes.hpp"
 #include "spectr/pattern.hpp"
+#include "spectr/preset_format.hpp"
 #include "spectr/snapshot.hpp"
+
+#include <pulp/state/store.hpp>
 
 #include <choc/text/choc_JSON.h>
 
@@ -151,6 +154,64 @@ std::string on_load_pattern_(Spectr& plugin, PatternLibrary* library,
     return ok_response();
 }
 
+// ── Preset handlers ────────────────────────────────────────────────────
+
+std::string on_save_preset_(Spectr& plugin, const choc::value::ValueView& payload) {
+    PresetMetadata meta;
+    meta.name        = get_string_(payload, "name");
+    meta.author      = get_string_(payload, "author");
+    meta.description = get_string_(payload, "description");
+    meta.created_at  = get_string_(payload, "created_at");
+    meta.modified_at = get_string_(payload, "modified_at");
+    const auto preset_json = save_preset_to_string(plugin, meta);
+
+    auto obj = choc::value::createObject("BridgeOk");
+    obj.addMember("ok",          true);
+    obj.addMember("preset_json", preset_json);
+    return choc::json::toString(obj, /*useLineBreaks=*/false);
+}
+
+std::string on_load_preset_(Spectr& plugin, const choc::value::ValueView& payload) {
+    const auto preset_json = get_string_(payload, "preset_json");
+    if (preset_json.empty()) return err_response("preset_json missing");
+
+    const auto result = load_preset_from_string(plugin, preset_json);
+    if (!result) {
+        return err_response(describe(result.error));
+    }
+    // Success — echo the metadata the preset carried so JS can refresh
+    // whatever UI labels its preset browser, without needing to
+    // re-parse the full envelope on its side.
+    auto obj = choc::value::createObject("BridgeOk");
+    obj.addMember("ok",             true);
+    obj.addMember("name",           result.metadata.name);
+    obj.addMember("author",         result.metadata.author);
+    obj.addMember("description",    result.metadata.description);
+    obj.addMember("created_at",     result.metadata.created_at);
+    obj.addMember("modified_at",    result.metadata.modified_at);
+    obj.addMember("plugin_version", result.plugin_version);
+    return choc::json::toString(obj, /*useLineBreaks=*/false);
+}
+
+std::string on_param_set_(Spectr& plugin, const choc::value::ValueView& payload) {
+    if (!payload.isObject() || !payload.hasObjectMember("id"))
+        return err_response("param id missing");
+    const auto id_v = payload["id"];
+    pulp::state::ParamID id{};
+    if      (id_v.isInt32()) id = static_cast<pulp::state::ParamID>(id_v.getInt32());
+    else if (id_v.isInt64()) id = static_cast<pulp::state::ParamID>(id_v.getInt64());
+    else                     return err_response("param id must be integer");
+
+    if (!payload.hasObjectMember("value"))
+        return err_response("param value missing");
+    const float value = get_float_(payload, "value", 0.0f);
+
+    // StateStore::set_value returns a bool in some versions; in ours
+    // the write is unconditional and the store range-clamps as needed.
+    plugin.state().set_value(id, value);
+    return ok_response();
+}
+
 } // namespace
 
 // ── Dispatch ───────────────────────────────────────────────────────────
@@ -169,12 +230,9 @@ std::string dispatch_editor_message(Spectr& plugin,
         if (type == "capture_snapshot")  return on_capture_snapshot_(plugin, state, payload);
         if (type == "ab_toggle")         return on_ab_toggle_(plugin, state, payload);
         if (type == "load_pattern")      return on_load_pattern_(plugin, library, payload);
-        // Reserved-for-future types return a distinguishable error so a
-        // JS caller sending these during development gets a clear
-        // signal rather than a silent drop.
-        if (type == "save_preset" ||
-            type == "load_preset" ||
-            type == "param_set")         return err_response("not implemented in this slice");
+        if (type == "save_preset")       return on_save_preset_(plugin, payload);
+        if (type == "load_preset")       return on_load_preset_(plugin, payload);
+        if (type == "param_set")         return on_param_set_(plugin, payload);
         return err_response("unknown message type");
     } catch (...) {
         return err_response("internal error");

--- a/src/spectr.cpp
+++ b/src/spectr.cpp
@@ -313,6 +313,15 @@ std::vector<uint8_t> Spectr::serialize_plugin_state() const {
     snaps.addMember("b", write_snapshot_(snapshots_.b));
     root.addMember("snapshots", snaps);
 
+    // M9.5 — user patterns. PatternLibrary::export_json() emits only
+    // user patterns (factory presets are rebuilt at construction) so
+    // the blob stays compact and a session reload rebuilds factories
+    // from code, not from the stored state. Embedded as a string
+    // because the library owns its own envelope shape and versioning
+    // — keeps the two serializers decoupled. Absent on a pre-9.5
+    // writer; readers treat absence as "no user patterns".
+    root.addMember("patterns_json", patterns_.export_json());
+
     auto json = choc::json::toString(root, /*useLineBreaks=*/false);
     return {json.begin(), json.end()};
 }
@@ -320,11 +329,12 @@ std::vector<uint8_t> Spectr::serialize_plugin_state() const {
 namespace {
 
 void reset_supplemental_state_(BandField& f, Viewport& v, Layout& l,
-                               SnapshotBank& bank) {
+                               SnapshotBank& bank, PatternLibrary& patterns) {
     f.reset();
     v = Viewport{};
     l = Layout::Bands32;
     bank = SnapshotBank{};
+    patterns = PatternLibrary{};  // restores factories, drops user patterns
 }
 
 // Symmetric with write_snapshot_(). Returns true if `obj` was read
@@ -394,7 +404,7 @@ bool Spectr::deserialize_plugin_state(std::span<const uint8_t> bytes) {
     // Empty span = legacy blob or caller signalling "reset to defaults"
     // per the pulp#625 hook contract.
     if (bytes.empty()) {
-        reset_supplemental_state_(field_, viewport_, layout_, snapshots_);
+        reset_supplemental_state_(field_, viewport_, layout_, snapshots_, patterns_);
         return true;
     }
 
@@ -483,9 +493,19 @@ bool Spectr::deserialize_plugin_state(std::span<const uint8_t> bytes) {
         if (snaps.hasObjectMember("b")) read_snapshot_(snaps["b"], new_bank.b);
     }
 
+    // M9.5 — user patterns. Apply into a fresh library so the factory
+    // presets are present regardless of what the blob carried; import
+    // appends the stored user patterns + default_id. Swap-on-success.
+    PatternLibrary new_patterns{};
+    if (root.hasObjectMember("patterns_json") && root["patterns_json"].isString()) {
+        const auto s = root["patterns_json"].getString();
+        new_patterns.import_json(std::string_view(s));
+    }
+
     field_     = new_field;
     viewport_  = new_view;
     snapshots_ = new_bank;
+    patterns_  = std::move(new_patterns);
     if (new_layout != layout_) set_layout(new_layout);
     return true;
 }

--- a/test/test_editor_bridge.cpp
+++ b/test/test_editor_bridge.cpp
@@ -10,10 +10,14 @@
 
 #include "spectr/editor_bridge.hpp"
 #include "spectr/pattern.hpp"
+#include "spectr/preset_format.hpp"
 #include "spectr/snapshot.hpp"
 #include "spectr/spectr.hpp"
 
 #include <pulp/state/store.hpp>
+
+#include <choc/containers/choc_Value.h>
+#include <choc/text/choc_JSON.h>
 
 #include <memory>
 #include <string>
@@ -75,16 +79,6 @@ TEST_CASE("M9.5 bridge: unknown type returns error") {
     const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
                                                    R"({"type":"not_a_message"})");
     CHECK(response_has_error(resp, "unknown message type"));
-}
-
-TEST_CASE("M9.5 bridge: reserved-for-future types return 'not implemented'") {
-    Rig r;
-    for (const auto* t : {"save_preset", "load_preset", "param_set"}) {
-        const auto msg = std::string(R"({"type":")") + t + R"("})";
-        const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge, msg);
-        INFO("type=" << t);
-        CHECK(response_has_error(resp, "not implemented"));
-    }
 }
 
 TEST_CASE("M9.5 bridge paint: paint without paint_start is rejected") {
@@ -212,4 +206,119 @@ TEST_CASE("M9.5 bridge load_pattern: without a library attached errors") {
     const auto resp = spectr::dispatch_editor_message_json(*r.proc, /*library*/nullptr,
         r.bridge, R"({"type":"load_pattern","payload":{"id":"factory:flat"}})");
     CHECK(response_has_error(resp, "pattern library"));
+}
+
+// ── M9.5 slice 2 — save_preset / load_preset / param_set ─────────────
+
+TEST_CASE("M9.5 bridge save_preset: returns the preset JSON in the response") {
+    Rig r;
+    r.store.set_value(spectr::kMix, 42.0f);
+    r.proc->field().bands[3].gain_db = -9.0f;
+
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"save_preset","payload":{"name":"Bridge Save","author":"Daniel"}})");
+    REQUIRE(response_ok(resp));
+    // Response embeds the preset JSON under "preset_json".
+    CHECK(resp.find("preset_json") != std::string::npos);
+    CHECK(resp.find("spectr.preset") != std::string::npos);  // format tag
+    CHECK(resp.find("Bridge Save") != std::string::npos);    // metadata round-trips
+}
+
+TEST_CASE("M9.5 bridge load_preset: applies and echoes metadata") {
+    // Build a preset from one rig, load it into another.
+    Rig a;
+    a.store.set_value(spectr::kMix, 18.0f);
+    a.proc->field().bands[10].gain_db = -3.0f;
+    spectr::PresetMetadata meta;
+    meta.name = "Bridge Load";
+    meta.author = "Test";
+    const auto preset = spectr::save_preset_to_string(*a.proc, meta);
+
+    Rig b;
+    // Escape the preset JSON inline via choc so the test doesn't have to
+    // hand-escape quotes in a raw string.
+    auto payload = choc::value::createObject("LoadPayload");
+    payload.addMember("preset_json", preset);
+    auto envelope = choc::value::createObject("Envelope");
+    envelope.addMember("type", "load_preset");
+    envelope.addMember("payload", payload);
+    const auto envelope_json = choc::json::toString(envelope, /*useLineBreaks=*/false);
+
+    const auto resp = dispatch_editor_message_json(*b.proc, &b.library, b.bridge,
+                                                   envelope_json);
+    REQUIRE(response_ok(resp));
+    CHECK(resp.find("Bridge Load") != std::string::npos);
+    CHECK(resp.find("\"author\": \"Test\"") != std::string::npos);
+    CHECK(b.store.get_value(spectr::kMix) == Approx(18.0f));
+    CHECK(b.proc->field().bands[10].gain_db == Approx(-3.0f));
+}
+
+TEST_CASE("M9.5 bridge load_preset: missing preset_json errors") {
+    Rig r;
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"load_preset","payload":{}})");
+    CHECK(response_has_error(resp, "preset_json missing"));
+}
+
+TEST_CASE("M9.5 bridge load_preset: malformed preset surfaces the load error") {
+    Rig r;
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"load_preset","payload":{"preset_json":"not valid"}})");
+    CHECK(response_has_error(resp, "JSON"));
+}
+
+TEST_CASE("M9.5 bridge param_set: writes to the StateStore") {
+    Rig r;
+    CHECK(r.store.get_value(spectr::kMix) == Approx(100.0f));   // default
+    const auto resp = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"param_set","payload":{"id":1,"value":73.5}})");
+    REQUIRE(response_ok(resp));
+    CHECK(r.store.get_value(spectr::kMix) == Approx(73.5f));
+}
+
+TEST_CASE("M9.5 bridge param_set: missing id or value errors") {
+    Rig r;
+    const auto no_id = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"param_set","payload":{"value":0}})");
+    CHECK(response_has_error(no_id, "param id missing"));
+
+    const auto no_val = dispatch_editor_message_json(*r.proc, &r.library, r.bridge,
+        R"({"type":"param_set","payload":{"id":1}})");
+    CHECK(response_has_error(no_val, "param value missing"));
+}
+
+// ── M9.5 slice 2 — PatternLibrary persistence through plugin_state ──
+
+TEST_CASE("M9.5 plugin_state: user patterns round-trip through serialize") {
+    Rig a;
+    // Save a user pattern with distinctive state.
+    a.proc->field().bands[5].gain_db = -7.0f;
+    a.proc->field().bands[6].gain_db = +2.0f;
+    const auto p = a.proc->patterns().save_current(a.proc->field(), "BridgeRoundTrip");
+    REQUIRE_FALSE(p.id.empty());
+
+    const auto blob = a.proc->serialize_plugin_state();
+
+    Rig b;
+    // Fresh rig starts with only factory patterns.
+    REQUIRE(b.proc->patterns().user().empty());
+    REQUIRE(b.proc->deserialize_plugin_state(blob));
+    // After load, the user pattern is back and factory presets are
+    // still there (rebuilt at PatternLibrary construction).
+    CHECK(b.proc->patterns().factory().size() == a.proc->patterns().factory().size());
+    CHECK(b.proc->patterns().user().size() == 1);
+    CHECK(b.proc->patterns().user().front().name == "BridgeRoundTrip");
+    CHECK(b.proc->patterns().user().front().gain_db[5] == Approx(-7.0f));
+    CHECK(b.proc->patterns().user().front().gain_db[6] == Approx(+2.0f));
+}
+
+TEST_CASE("M9.5 plugin_state: empty-span reset clears user patterns") {
+    Rig r;
+    r.proc->patterns().save_current(r.proc->field(), "Temp");
+    REQUIRE_FALSE(r.proc->patterns().user().empty());
+    // pulp#625 contract: empty span means "reset to defaults".
+    REQUIRE(r.proc->deserialize_plugin_state({}));
+    CHECK(r.proc->patterns().user().empty());
+    // Factories still present (reconstructed by PatternLibrary()).
+    CHECK_FALSE(r.proc->patterns().factory().empty());
 }


### PR DESCRIPTION
Lights up three bridge handlers the schema already reserved and closes the "PatternLibrary is memory-only" gap flagged in the slice 1 PR.

## What's in

**Bridge handlers** (schema documented in \`include/spectr/editor_bridge.hpp\`):
- \`save_preset\` — response embeds the serialized preset JSON under \`preset_json\`. JS owns the filesystem hop so the bridge stays sandbox-friendly.
- \`load_preset\` — applies to StateStore + plugin-supplemental state via the existing \`preset_format\` pipeline; response echoes metadata + \`plugin_version\`. Errors surface the \`PresetLoadError\` message.
- \`param_set\` — writes through \`StateStore::set_value\` so undo groups + snapshot capture see the write.

**PatternLibrary persistence**:
- \`serialize_plugin_state\` embeds \`patterns_.export_json()\` under \`patterns_json\` (factory presets rebuild at construction; export_json emits only user patterns + default-id).
- \`deserialize_plugin_state\` imports into a fresh \`PatternLibrary\` and swaps. Empty-span deserialize now also clears user patterns.

## Tests

\`\`\`
100% tests passed, 0 tests failed out of 110
\`\`\`

110/110 green (103 prior + 7 new). Also dropped the slice-1 "reserved-for-future types return 'not implemented'" test since those types are now implemented.

## Not yet in M9.5

- HTML-side JS shim posting these messages from the prototype's UI events — bundled-template surgery still TBD.
- \`state_push\` (C++ → JS) for automation-to-UI sync.