### PR TITLE
chore: bump Shipyard pin v0.29.0 → v0.44.0

### DIFF
--- a/tools/shipyard.toml
+++ b/tools/shipyard.toml
@@ -21,10 +21,24 @@
 # the cumulative release-note history.
 
 [shipyard]
-# v0.29.0 — tracks pulp's pin as of 2026-04-23. See pulp's
-# tools/shipyard.toml for the cumulative release-note history of each
-# version on the v0.2x line.
-version = "v0.29.0"
+# v0.44.0 — tracks pulp's pin. Jump from v0.29.0 covers the full chain
+# of fixes Shipyard shipped after the 2026-04-23 SIGKILL incident:
+#
+#   - v0.36.0 / Shipyard #203 — install.sh notarization-preserve (the
+#     pre-v0.36 installer ad-hoc-resigned over the Dev-ID signature,
+#     which Gatekeeper killed after a background-scan window).
+#   - v0.41.0 / Shipyard #181 — rich-bundle `shipyard doctor` check.
+#   - v0.43.0 / Shipyard #216 — Gatekeeper/quarantine/codesign doctor
+#     check + post-install `shipyard --version` smoke test.
+#   - v0.44.0 / Shipyard #219 — macOS ships as a **stapled .dmg** so
+#     Gatekeeper can verify offline. Ends the taskgated-cache
+#     flakiness the earlier v0.42.0 / v0.43.0 binary builds hit on
+#     this account (silent exit 137, "Taskgated Invalid Signature"
+#     crash reports). install.sh handles the dmg → extract step
+#     transparently.
+#
+# See pulp's tools/shipyard.toml for the full per-release history.
+version = "v0.44.0"
 
 # Public release source. The bootstrap script downloads from
 # https://github.com/{repo}/releases/download/{version}/{asset}


### PR DESCRIPTION
Tracks pulp's parallel bump. First Shipyard version since v0.29 that **actually launches** on this account: v0.44.0 ships macOS as a **stapled .dmg** ([Shipyard #219](https://github.com/danielraffel/Shipyard/issues/219)), ending the taskgated-cache flakiness that made v0.42 and v0.43 exit-137 SIGKILL on this host.

## Full verification on this host

- [x] Edit \`version = \"v0.44.0\"\` in \`tools/shipyard.toml\`
- [x] \`./tools/install-shipyard.sh\` — installed cleanly, no smoke-test failure
- [x] \`shipyard --version\` → \`shipyard, version 0.44.0\` (exit 0)
- [x] Restarted daemon (\`shipyard daemon stop && shipyard daemon start\`) — cleared the v0.38 → v0.44 version drift. Filed [Shipyard #231](https://github.com/danielraffel/Shipyard/issues/231) for the auto-restart enhancement + release-time upgrade-path smoke-test matrix.
- [x] \`shipyard doctor\` — Core rows all ✓ **except** \`macos-gatekeeper\` which remains ✗ (stale cache from earlier v0.42/v0.43 attempts; cross-referenced in #231 comment).
- [x] \`shipyard run\` — **green**. \`sy-20260424-31b55b / mac pass / local / 30m11s\`. 110 Spectr tests pass via the CI lane.

## What changed end-to-end

\`\`\`
v0.29 → v0.36 → v0.41 → v0.43 → v0.44
       #203       #181    #216     #219
  notarization  doctor  smoke    stapled dmg
   preserve    richb.  +gate-c    (THE fix)
\`\`\`

Supersedes the closed [#9 (v0.42)](https://github.com/danielraffel/spectr/pull/9) and [#10 (v0.43)](https://github.com/danielraffel/spectr/pull/10), both blocked on the pre-stapled-dmg failure mode.