### PR TITLE
feat: pick up EditorBridge::detach_webview + bump Pulp SDK v0.42.0

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -24,7 +24,7 @@ platforms = ["macos"]
 
 [validation.default]
 stages    = ["configure", "build", "test"]
-configure = "cmake -S . -B build -DCMAKE_PREFIX_PATH=$HOME/.pulp/sdk/0.41.1 -DCMAKE_BUILD_TYPE=Debug"
+configure = "cmake -S . -B build -DCMAKE_PREFIX_PATH=$HOME/.pulp/sdk/0.42.0 -DCMAKE_BUILD_TYPE=Debug"
 build     = "cmake --build build --parallel"
 test      = "ctest --test-dir build --output-on-failure"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Spectr VERSION 1.0.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Pulp 0.41.1 REQUIRED)
+find_package(Pulp 0.42.0 REQUIRED)
 
 # ── Core Spectr sources ────────────────────────────────────────────────
 #

--- a/include/spectr/ui/editor_view.hpp
+++ b/include/spectr/ui/editor_view.hpp
@@ -63,12 +63,12 @@ private:
     // makes it a compile-error to put it in a moveable container),
     // so we construct it in place as a direct member.
     //
-    // Remaining race window: between `set_message_handler` clearing
-    // on panel_ destruction and the native WebView's last in-flight
-    // callback completing. The WebViewPanel impl may or may not
-    // synchronously cancel — no `bridge_.detach_webview()` exists in
-    // Pulp v0.41.1 to make this explicit. See [pulp FR] for the
-    // symmetric `detach_webview()` we'd use here.
+    // Teardown order is now explicit: detach_if_needed() calls
+    // bridge_.detach_webview(*panel_) before the native child view
+    // comes off the host, so the race window that existed in
+    // Pulp v0.41.1 (between set_message_handler clearing and the
+    // WebView's last in-flight callback) is closed. Symmetric
+    // teardown landed in pulp#728 (fixes #726).
 
     Spectr&                                   plugin_;
     EditorDragState                           drag_{};

--- a/src/ui/editor_view.cpp
+++ b/src/ui/editor_view.cpp
@@ -174,6 +174,13 @@ void EditorView::detach_if_needed() {
         attached_ = false;
         return;
     }
+    // Explicit teardown order: clear the bridge's WebView handler
+    // BEFORE the native child view comes off the host. This closes
+    // the residual race where the panel's last in-flight WebView
+    // callback could dispatch through the bridge after panel_
+    // destruction started. Symmetric partner of attach_webview(),
+    // added in pulp#728 (fixes #726).
+    bridge_.detach_webview(*panel_);
     auto host = find_native_child_host(this);
     if (host) host.detach(panel_->native_handle());
     attached_ = false;


### PR DESCRIPTION
## Summary

- Wire `bridge_.detach_webview(*panel_)` into `EditorView::detach_if_needed()` for explicit teardown order. Closes the residual race where the panel's last in-flight WebView callback could dispatch through the bridge after `panel_` destruction started.
- Bump Pulp SDK v0.41.1 → v0.42.0, which shipped the symmetric `detach_webview()` API via pulp#728 (fixes pulp#726).

## Context

Before v0.42.0, the Spectr editor relied entirely on reverse-declaration-order member destruction (panel_ destroyed FIRST, bridge_ destroyed after) to keep teardown safe. That closed most of the window, but a narrow race remained between `panel_->set_message_handler(nullptr)` firing on panel destruction and the native WebView's last in-flight callback completing. The new `EditorBridge::detach_webview()` makes the handler clear explicit and deterministic.

## Changes

- `src/ui/editor_view.cpp` — `detach_if_needed()` now calls `bridge_.detach_webview(*panel_)` before the native child view comes off the host.
- `include/spectr/ui/editor_view.hpp` — destruction-order comment updated to reflect the explicit teardown path; the "Remaining race window" language that called out v0.41.1 is replaced with a reference to pulp#728.
- `CMakeLists.txt` — `find_package(Pulp 0.42.0 REQUIRED)`.
- `.shipyard/config.toml` — `CMAKE_PREFIX_PATH` updated to `~/.pulp/sdk/0.42.0`.
- `pulp.toml` (gitignored) — `sdk_version` / `sdk_path` updated locally.

## Test plan

- [x] Local clean build against ~/.pulp/sdk/0.42.0
- [x] `ctest --test-dir build` → 109/109 passing
- [ ] CI (mac) green via `shipyard ship`

## Refs

- pulp#728 — PR that landed the API
- pulp#726 — original gap tracking issue (now closed)
- pulp v0.42.0 release notes: https://github.com/danielraffel/pulp/releases/tag/v0.42.0