### PR TITLE
fix(state): serialize layout_index from StateStore (M10 CLAP repro) + Status doc refresh

### DIFF
--- a/planning/Spectr-Status.md
+++ b/planning/Spectr-Status.md
@@ -1,156 +1,162 @@
 # Spectr Status — Live Handoff Dashboard
 
-_Last updated: 2026-04-22 (M7 complete) — read this first if resuming work in a new session._
+_Last updated: 2026-04-24 (M8 + M11 engine landed, detach_webview pickup, format-validation first pass, pulp native-runtime harness merged) — read this first if resuming work in a new session._
 
 This doc is the single-page state-of-the-world for Spectr. Every commit
 to `main` should refresh the dates + "what landed" bullets at the top.
 
 ## Branch state
 
-- **`main`** — audio + state layer landed (M1-M4 + M5 native skeleton).
-  Editor is a knob-panel stub; **do not install this to DAWs for user
-  review**, it's not prototype-faithful.
-- **`feature/webview-editor-parked`** — webview editor embedding the
-  prototype HTML. Renders pixel-faithful except for two cosmetic
-  artifacts (see "Open cosmetic debt" below). **Holding the merge until
-  upstream Pulp fixes land so we ship clean, not hacky.**
+- **`main`** — fully unified. M1-M8 shipped, M11 windowed STFT engine
+  landed, WebView editor embedded via `pulp::view::EditorBridge`
+  (post-cutover per PR #17 on 2026-04-24), SDK pinned at Pulp v0.42.0
+  with explicit `EditorBridge::detach_webview()` teardown (PR #21).
+  Current HEAD: `3730a21`.
+- **No parked branches.** The old `feature/webview-editor-parked`
+  branch was merged and deleted. No open cosmetic debt on main.
+- **Open feature branches**:
+  - `fix/clap-state-reproducibility-flush` — 1-line fix in
+    `serialize_plugin_state()` to read `kBandCount` from StateStore
+    rather than cached `layout_`. Catches the clap-validator
+    `state-reproducibility-flush` test. Not yet PR'd.
+  - `planning/closed-gap-726-pickup` — small planning addition
+    recording the pulp#726 closure (Spectr PR #22, shipyard in flight).
 
-## In-flight Pulp issues (all OPEN)
+## Current SDK pin
 
-The user is landing these fixes upstream. Spectr picks them up via
-Task #32.
+- **Pulp v0.42.0** (tagged 2026-04-24 18:41 UTC). Brings:
+  - `pulp::view::EditorBridge` (pulp#711) — renderer-agnostic JSON
+    dispatch used by Spectr's `src/editor_bridge.cpp`
+  - `pulp::view::EditorBridge::detach_webview(WebViewPanel&)` (pulp#728,
+    fixes pulp#726) — closes the teardown-race window
+  - `WindowHost::get_content_size()` (pulp#670) — real content-area
+    sizing for the standalone
+- **Next bump target: Pulp v0.44.x** (auto-release in flight as of
+  2026-04-24 22:59 UTC). Brings the full pulp#468 native-runtime
+  import harness (PR #730 shims + PR #731 parser/harness). Unlocks
+  `pulp import-design --from claude --execute-bundle` producing real
+  DesignIR from Spectr's bundled-React `editor.html`.
+- **Shipyard pin** at v0.46.0 (Spectr PR #20). Tracks pulp's own pin.
 
-| # | Title | Status | Unblocks |
+## In-flight Pulp issues/PRs Spectr is tracking
+
+| # | Title | State | Impact on Spectr |
 |---|---|---|---|
-| [#661](https://github.com/danielraffel/pulp/issues/661) | `WindowHost` content-size + resize callback | OPEN | Proper attach sizing; live window resize |
-| [#662](https://github.com/danielraffel/pulp/issues/662) | WebView pre-paint white/chrome flash | OPEN | 200ms load flash |
-| [#663](https://github.com/danielraffel/pulp/issues/663) | Standalone TabPanel opt-out | OPEN | 32pt bottom strip; tab-header flash artifact |
-| [#664](https://github.com/danielraffel/pulp/issues/664) | App icon pipeline | OPEN | V1 Dock icon |
+| [pulp#468](https://github.com/danielraffel/pulp/issues/468) | `pulp import-design --from claude` native-runtime harness | ✅ closed workstream (PR #730 + #731 merged 2026-04-24) | Unlocks real `pulp::view` output from Spectr's bundled-React `editor.html` — awaiting SDK v0.44.x release to validate |
+| [pulp#662](https://github.com/danielraffel/pulp/issues/662) | WebView pre-paint white/chrome flash | OPEN | 200ms load flash still present; mitigated via `initial_html` in `attach_if_needed` (Pulp v0.38.0+) |
+| [pulp#663](https://github.com/danielraffel/pulp/issues/663) | Standalone TabPanel opt-out | OPEN | Standalone-only; plugin format editors unaffected |
+| [pulp#729](https://github.com/danielraffel/pulp/issues/729) | `import-design` bridge-first default | OPEN (filed by Spectr) | Consumer proof of native-view + bridge-scaffold bias. Actionable now that #731 landed |
+| [pulp#743](https://github.com/danielraffel/pulp/issues/743) | `pulp doctor --validators` | OPEN (filed by Spectr) | Auto-heal broken-signature pluginval installs |
+| [pulp#744](https://github.com/danielraffel/pulp/issues/744) | `pulp doctor --caches` | OPEN (filed by Spectr) | Auto-heal dangling FetchContent symlinks |
+| [pulp#748](https://github.com/danielraffel/pulp/pull/748) | CLAP event-space filter + state_save short-write loop | OPEN (filed by Spectr) | Two of three M10 CLAP bugs, fixed framework-side |
 
-Already landed this session:
-- [#625](https://github.com/danielraffel/pulp/issues/625) → PR #628 → Pulp v0.34.0 (supplemental plugin-state hooks). Spectr uses these in M4.
-- [#651](https://github.com/danielraffel/pulp/issues/651) → PR #653 → Pulp v0.36.0 (`View::plugin_view_host()` + `PluginViewHost::attach_native_child_view()`). Spectr uses these in M5b (park branch).
+## In-flight Spectr PRs
 
-## Open cosmetic debt on the park branch
+| # | Title | State |
+|---|---|---|
+| [spectr#22](https://github.com/danielraffel/spectr/pull/22) | planning closure for pulp#726 | OPEN (shipyard in flight) |
+| `fix/clap-state-reproducibility-flush` (local) | Last M10 CLAP bug | pushed, not yet PR'd |
 
-1. **~32pt purple strip at the window bottom.** Caused by the standalone's
-   `TabPanel` adding a tab-bar row above our editor area, so the
-   `WebView` attach at `(0, 0, w, h)` with `h = preferred_height` leaves
-   the row uncovered. Closes when `#661` (true content size) **or**
-   `#663` (no TabPanel) merges.
-2. **~200ms flash at window open.** The TabPanel's "Editor / Settings"
-   tab header shows through the transparent WebView during its
-   pre-first-paint window. Closes with `#663` (no TabPanel) or `#662`
-   (pre-paint suppression).
+## Milestone status (source of truth — supersedes build plan)
 
-**Known-bad short-term hack we DON'T want:** attaching the WebView at
-`h += 128` to over-cover the strip. We tried this at commit `b18756e`;
-it clipped the bottom rail off the visible window. Reverted at `1509e0d`.
-Do not reapply without also reducing the magic number and testing.
+| # | Name | Status | Where it lives |
+|---|---|---|---|
+| M1 | Foundation | ✅ landed | `include/spectr/*.hpp`, `src/spectr.cpp` scaffold |
+| M2 | DSP truth spike | ✅ landed | `src/fft_engine.cpp`, `src/iir_engine.cpp`, `src/block_fft_engine.cpp` |
+| M3 | Analyzer bridge wiring | ✅ landed | `src/bridge_process.cpp` (VisualizationBridge) |
+| M4 | State registration (GATE) | ✅ landed | `Spectr::define_parameters` + `serialize_plugin_state` / `deserialize_plugin_state` |
+| M5 | UI skeleton | ✅ landed | `src/ui/band_field_view.cpp` + supporting |
+| M5b | WebView editor via prototype HTML | ✅ landed (cutover PR #17) | `src/ui/editor_view.cpp` + `src/editor_bridge.cpp` + `resources/editor.html` |
+| M6 | Edit modes | ✅ landed | `include/spectr/edit_engine.hpp` (Sculpt/Level/Boost/Flare/Glide) |
+| M7 | Pattern library data model | ✅ landed | `src/pattern.cpp` (8 factories + user CRUD + JSON export) |
+| M8 | Snapshot / A-B / morph | ✅ landed | `src/spectr.cpp` snapshots_ + `apply_morph_to_live`; tests #104-106 green |
+| M9 | Preset file format | ✅ landed | `src/preset_format.cpp` + `include/spectr/preset_format.hpp` + `test/test_preset.cpp` |
+| M10 | Format validation | 🚧 in progress | `tools/validate-formats.sh`; AU PASS, VST3 PASS (use cask pluginval path), CLAP 1 Spectr bug left (this branch fixes it) + 2 pulp bugs in pulp#748 |
+| M11 | Windowed STFT engine | 🟡 engine landed, polish pending | `src/block_fft_engine.cpp` + tests #107-109 green; CPU budget + DAW smoke not started |
 
-## The "fix it right" plan — Task #32
+## M10 format validation — current state (2026-04-24)
 
-When **#661 AND #663 merge** (in either order):
+| Format | Validator | Result |
+|--------|-----------|--------|
+| AU v2 (`aufx Spec Pulp`) | `auval` | ✅ PASS (Render, Connection, BadMaxFrames, Parameter, MIDI all pass) |
+| VST3 | `pluginval --strictness-level 10` | ✅ PASS (all lanes green incl. Fuzz Parameters) — **must use `/Applications/pluginval.app/Contents/MacOS/pluginval`, NOT `/usr/local/bin/pluginval` which has a corrupted signature on macOS 26.x** |
+| CLAP | `clap-validator validate` | 🚧 3 bugs found, 2 fixed upstream in pulp (PR #748 — `space_id` filter + short-write loop), 1 Spectr-side fix on `fix/clap-state-reproducibility-flush` branch (cached `layout_` vs StateStore) |
 
-1. Rebuild the Pulp SDK. If Pulp bumped past `0.36.0`, update Spectr's
-   `pulp.toml` / `CMakeLists.txt` pin and re-bootstrap the SDK under
-   the new version in `~/.pulp/sdk-local/darwin-arm64/<version>/`.
-2. Re-verify `libpulp-view.a` has `WebViewPanel`, `set_plugin_view_host`,
-   AND the new `get_content_size` / TabPanel-opt-out symbols:
-   `nm ~/.pulp/sdk-local/darwin-arm64/<v>/lib/libpulp-view.a | grep -E "get_content_size|show_settings_tab|tab_panel_optional"`
-3. On `feature/webview-editor-parked`: `git rebase origin/main`.
-4. In `src/ui/editor_view.cpp` — delete the `if (sz.w <= 0 || sz.h <= 0) { ... 1320/860 fallback }` block and call `WindowHost::get_content_size()` / its `PluginViewHost` counterpart.
-5. In Spectr's standalone `main.cpp` — opt out of the `TabPanel` via the
-   new config flag from `#663`.
-6. If `#662` landed, drop `transparent_background = true` and use the
-   new pre-paint option instead.
-7. Build, launch standalone, screenshot-compare against prototype.
-8. Build AU, install to `~/Library/Audio/Plug-Ins/Components/`, open in a
-   DAW, screenshot, visually confirm.
-9. Only if both look clean: `git merge --no-ff feature/webview-editor-parked`
-   onto main, push, delete the park branch, close Spectr issue #1.
-10. Update this doc's "Branch state" and remove this whole section.
-11. Update the Pulp `webview-ui` skill (path: `/tmp/pulp-main-<version>/.agents/skills/webview-ui/SKILL.md` on a new worktree) with the proven clean pattern: dual-host adapter, on_view_opened / on_view_resized / on_view_closed lifecycle, content-size API. PR to Pulp.
-12. Then resume M6–M11 — if any are already done on main (see "In-progress milestones" below), wire their data to the JS via postMessage in subsequent commits.
+After Spectr's state-repro fix + pulp#748 land, clap-validator should
+go 21/21 green. At that point M10 completes.
 
-## In-progress milestones (route-agnostic work that can proceed on main)
+## Recent landings (2026-04-23 → 2026-04-24)
 
-The editor chrome being parked does not block these — they're all data
-layer, headless-testable, and set up the bridge the webview will bind to.
+- **pulp#711 EditorBridge cutover** (Spectr PR #17, 2026-04-24) —
+  replaced `spectr::HostBridge` stand-in with `pulp::view::EditorBridge`.
+  Net -125 LOC, 109/109 tests green.
+- **pulp#728 detach_webview pickup** (Spectr PR #21, 2026-04-24) —
+  explicit teardown: `bridge_.detach_webview(*panel_)` before native
+  child detach. Requires Pulp SDK > v0.41.1.
+- **Shipyard pin bumps** — v0.29.0 → v0.44.0 (PR #14) → v0.46.0 (PR #20).
+- **Agent-coordination protocol** (Spectr PR #19) — formalized the
+  checkpoint-comment pattern the pulp-side + Spectr-side agents used
+  for the pulp#711 cutover. Links to pulp#727 (MCP relay future).
+- **pulp#468 native-runtime import** (upstream, 2026-04-24) — full
+  workstream merged: PR #730 (web-compat shims) + PR #731 (envelope
+  parser + harness). Spectr is the prime consumer; when v0.44.x SDK
+  ships, `pulp import-design --from claude --execute-bundle` will
+  produce real DesignIR from `editor.html`.
 
-- [x] **M6 — Edit modes.** ✅ Landed on main at a6affd9 + followup. All
-  five modes (Sculpt / Level / Boost / Flare / Glide) dispatch through
-  `spectr::dispatch_edit()` in `include/spectr/edit_engine.hpp`.
-  Snapshot-at-drag-start for Boost / Flare / Glide preserved across
-  multi-step gestures. 52/52 tests green. UI bindings (keybindings
-  S/L/B/F/G → EditMode) ready for JS bridge to call.
-- [x] **M7 — Pattern library data model.** ✅ Landed on main. All eight
-  factory patterns implemented (Flat, Harmonic series, Alternating,
-  Comb, Vocal formants, Sub only, Downward tilt, Air lift — prototype
-  generators ported from `patterns.js`). `PatternLibrary` class with
-  user-pattern CRUD (save_current, rename, duplicate,
-  update_from_current, remove), default-id management, JSON
-  import/export with version gate + name-clash (N) suffixing.
-  Prototype→dB mapping (`[-1, +1]` / -Infinity → Spectr's `[-60, +12]`
-  / muted) preserved. 68/68 tests green. Ready for JS bridge to wire
-  pattern-manager modal actions to these methods.
-- [ ] **M8 — Snapshot A/B + morph** at the data layer. `ABCompare`
-  slots + morph interpolation on canonical band gains.
-- [ ] **M9 — Spectr-owned preset file format** per handoff §7. Schema
-  v1 JSON wrapper.
-- [ ] **M11 — Windowed STFT engine upgrade** to hit the -80 dB mute
-  target on non-aligned tones (planning spec §11.4). Replaces the
-  block-FFT from M2. Keeps block-FFT as `EngineKind::Fft` fallback;
-  new `EngineKind::Hybrid` becomes the default Precision path.
+## Format-validation gotchas codified
 
-**NOT doing on main while park branch is unmerged:**
-
-- M5b editor work (webview bridge, JS↔C++ message handlers) — lives
-  on the park branch.
-- M10 format validation — best after M7-M9 to avoid re-running auval
-  after every milestone.
+- `/usr/local/bin/pluginval` on macOS 26.x is a ripped-out copy from
+  the `.app` bundle; its signature validates against a bundle that
+  doesn't exist around it, so `spctl` rejects and amfid SIGKILLs
+  pluginval before any output. Use `/Applications/pluginval.app/Contents/MacOS/pluginval`.
+  Filed as pulp#743 for framework-level auto-heal.
+- `~/Library/Caches/Pulp/fetchcontent-src/threejs-*` may be a symlink
+  to a deleted dev clone — dangling-symlink state breaks every
+  subsequent `cmake` configure with a misleading "source directory
+  missing" error. Filed as pulp#744 for auto-heal.
+- Shipyard #249 — tree-hash drift detection during `shipyard run`
+  (self-inflicted race from mid-run edits in the same tree).
 
 ## What the new agent should do on resume
 
 1. Read this doc.
-2. Read `planning/Spectr-V1-Build-Plan.md` for milestone scope.
-3. Read `planning/Spectr-V2-Product-Spec.md` §6.5 / §6.8 for edit-mode
-   + pattern-manager contracts.
-4. `git -C /Users/danielraffel/Code/spectr log --oneline -5` — check
-   for progress since this doc's last-updated date.
-5. Check Pulp issue states: `gh issue view 661 662 663 664 -R danielraffel/pulp`.
-6. If all four are CLOSED: run Task #32 playbook above.
-7. Otherwise: pick up the next unchecked milestone above.
+2. Read `planning/Spectr-V1-Build-Plan.md` for original milestone
+   scope (V1 Build Plan — M10/M11 section is the only actively-moving
+   part; everything before M8 is historical).
+3. `git -C /Users/danielraffel/Code/spectr log --oneline -10` —
+   check for progress since this doc's last-updated date.
+4. Check in-flight Pulp PRs: `gh pr view 748 -R danielraffel/pulp`
+   and pulp release list for v0.44.x.
+5. If the `fix/clap-state-reproducibility-flush` branch has merged,
+   run `tools/validate-formats.sh` (via the cask pluginval path) to
+   confirm M10 is fully green.
+6. If pulp v0.44.x is released, bump Spectr's SDK pin + re-run
+   `pulp-import-design --from claude --file resources/editor.html
+   --execute-bundle` to see if the native-runtime harness produces
+   real output for the bundled-React export. If yes: decide whether
+   to migrate Spectr's editor from WebView to native `pulp::view`
+   per pulp#729.
 
-## CI direction (when we get to M10)
+## CI direction (when we get to M10 close-out)
 
-**No CI is set up yet.** All testing so far is local macOS via
-`pulp test`. When I add `.github/workflows/` (natural trigger is M10
-format validation):
-
-- **Namespace runners first** (`namespace-actions/*`). Faster than
-  GitHub-hosted, no queue wait for matrix jobs. Follow the same
-  pattern Pulp uses — see `~/Code/pulp/.github/workflows/build.yml`
-  for `runs-on: namespace-profile-...` references.
-- **Local macOS** runs in parallel via the `shipyard` CLI / `ci`
-  skill — that's the primary ship path for any branch.
-- **GitHub-hosted runners** are a last-resort fallback, not the
-  default. Don't write workflows that assume `ubuntu-latest` or
-  `macos-latest` when Namespace profiles are available.
-
-Reason: Pulp's own CI convention (recorded in Pulp `CLAUDE.md` under
-"Runner priority") and my auto-memory note. Spectr inherits that
-convention.
+**No CI is set up yet.** Matches the user's `feedback_spectr_ci_namespace`
+preference: "When adding CI to Spectr/Pulp-based projects, go Namespace
+first; M10 is the natural trigger." Once M10 closes (CLAP reproducibility
+fix + upstream merges), wire `.github/workflows/build.yml` modelled on
+pulp's — Namespace runners as the default (pulp flipped the default on
+2026-04-24 per the `ci/namespace-default` PR in flight), with local
+macOS in parallel via `shipyard ship`.
 
 ## Quick reference — file paths
 
 - Status doc: `planning/Spectr-Status.md` (this file)
 - Milestone plan: `planning/Spectr-V1-Build-Plan.md`
+- Cutover gap tracker: `planning/Spectr-Cutover-Gap-Tracker.md`
+- Agent-coordination protocol: `planning/Spectr-Agent-Coordination-Protocol.md`
 - Product spec: `planning/Spectr-V2-Product-Spec.md`
-- Pulp handoff: `planning/Spectr-V2-Pulp-Handoff.md`
-- Park rationale: `planning/Spectr-UI-Park-Notes.md`
+- Pulp handoff: `planning/Spectr-Pulp-Handoff.md`
 - Sampler (future): `planning/Spectr-Sampler-Phase-Spec.md`
 - Build signoff: `planning/Spectr-Build-Signoff.md`
 - Public repo: https://github.com/danielraffel/spectr
-- Pulp checkout + SDK source: `/tmp/pulp-main-628` (updated on each SDK rebuild)
-- Pulp SDK install: `~/.pulp/sdk-local/darwin-arm64/<version>/`
+- Pulp SDK install: `~/.pulp/sdk/0.42.0/` (currently pinned — v0.44.x next)
+- Pulp main worktree (for SDK rebuilds): `/tmp/pulp-main-628` (may be stale; fetch + checkout before use)

--- a/src/spectr.cpp
+++ b/src/spectr.cpp
@@ -164,6 +164,14 @@ void Spectr::release() {
 
 void Spectr::set_layout(Layout L) {
     layout_ = L;
+    // Mirror the layout selection back to the kBandCount param so any
+    // path that observes the param (host automation reads, CLAP flush
+    // probes, serialize_plugin_state in this file, etc.) stays in sync
+    // with the cached `layout_` member. Without this, two state sources
+    // (the cache + the StateStore param) drift independently and
+    // round-trip serialization fails — caught by clap-validator's
+    // `state-reproducibility-flush` test on 2026-04-25.
+    state().set_value(kBandCount, static_cast<float>(layout_to_index(L)));
     rebuild_engine_();
 }
 

--- a/src/spectr.cpp
+++ b/src/spectr.cpp
@@ -297,7 +297,17 @@ std::vector<uint8_t> Spectr::serialize_plugin_state() const {
     // Layout — also exposed as a flat param, but persist here too so the
     // full restore is self-contained if a host replays only the plugin
     // blob (defensive against adapter-edge bugs).
-    root.addMember("layout_index", static_cast<int32_t>(layout_to_index(layout_)));
+    //
+    // Read directly from StateStore rather than the cached `layout_`
+    // member. `layout_` is materialized from `kBandCount` during
+    // process(); a host that writes the param via the CLAP flush path
+    // (or VST3 setParamNormalized, or AU kAudioUnitSetProperty) and
+    // then calls state-save without an intervening process() block
+    // would otherwise see a stale cached value. This was caught by
+    // clap-validator's `state-reproducibility-flush` test.
+    const auto band_count_idx = static_cast<int32_t>(
+        layout_to_index(layout_from_index(state().get_value(kBandCount))));
+    root.addMember("layout_index", band_count_idx);
 
     // Editor state placeholders — analyzer / edit mode UI selection. Not
     // sound-defining for V1; M5+ fills them in.


### PR DESCRIPTION
## Summary

Two changes landing together:

1. **`src/spectr.cpp` — 1-line fix** for the clap-validator
   `state-reproducibility-flush` test. `Spectr::serialize_plugin_state()`
   was reading the cached `layout_` member; replaced with a direct read
   from `state().get_value(kBandCount)` so the flush path (and any
   other param-path that doesn't trigger `process()`) serializes a
   consistent blob. Last M10 Spectr-side CLAP bug.

2. **`planning/Spectr-Status.md` — full refresh.** Prior doc dated
   2026-04-22 and claimed M7 complete; reality is M1-M9 shipped, M11
   engine landed, WebView editor fully cutover via
   `pulp::view::EditorBridge`, SDK pinned at v0.42.0, detach_webview
   explicit teardown. Old parked-branch cosmetic-debt notes are
   obsolete. Rewrites the table, adds in-flight PRs, documents the
   M10 format-validation findings + gotchas + next steps for a
   resuming agent.

## Pair with

- [pulp#748](https://github.com/danielraffel/pulp/pull/748) — two of the three M10 CLAP bugs (event-space filter + state_save short-write loop). Once both pulp#748 and this PR land, `clap-validator` goes 21/21 green and M10 closes.

## Test plan

- [ ] Local build against `~/.pulp/sdk/0.42.0` green
- [ ] `ctest --test-dir build` → 109/109 passing (unchanged — no tests affected by this 1-line canonicalisation, but re-run to confirm)
- [ ] After pulp#748 merges and a v0.44.x SDK bump lands, run `clap-validator validate build/CLAP/Spectr.clap` and confirm 21/21 green