### PR TITLE
M10: bump SDK to 0.47.0, close clap-validator gap

### DIFF
--- a/.shipyard/config.toml
+++ b/.shipyard/config.toml
@@ -24,7 +24,7 @@ platforms = ["macos"]
 
 [validation.default]
 stages    = ["configure", "build", "test"]
-configure = "cmake -S . -B build -DCMAKE_PREFIX_PATH=$HOME/.pulp/sdk/0.42.0 -DCMAKE_BUILD_TYPE=Debug"
+configure = "cmake -S . -B build -DCMAKE_PREFIX_PATH=$HOME/.pulp/sdk/0.47.0 -DCMAKE_BUILD_TYPE=Debug"
 build     = "cmake --build build --parallel"
 test      = "ctest --test-dir build --output-on-failure"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Spectr VERSION 1.0.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Pulp 0.42.0 REQUIRED)
+find_package(Pulp 0.47.0 REQUIRED)
 
 # ── Core Spectr sources ────────────────────────────────────────────────
 #

--- a/src/spectr.cpp
+++ b/src/spectr.cpp
@@ -214,7 +214,19 @@ void Spectr::process(
 
     if (rm != response_mode_) response_mode_ = rm;
     if (ek != engine_kind_)  set_engine_kind(ek);
-    if (desired_layout != layout_) set_layout(desired_layout);
+    if (desired_layout != layout_) {
+        // Sync the cached layout_ from the host-driven kBandCount value
+        // without calling set_layout() — that path writes the quantized
+        // index back to kBandCount, which makes the param value diverge
+        // between the process and flush paths (clap_plugin_params::flush
+        // doesn't run process and so wouldn't see the writeback). The
+        // StateStore-side raw float must stay byte-equal across both
+        // paths for clap-validator's state-reproducibility-flush test.
+        // Direct UI calls to set_layout() still writeback for the
+        // serialize-from-cache path covered by test_m4_state.cpp.
+        layout_ = desired_layout;
+        rebuild_engine_();
+    }
 
     if (engine_) {
         engine_->process(output, input, field_, viewport_, layout_, response_mode_);
@@ -524,7 +536,16 @@ bool Spectr::deserialize_plugin_state(std::span<const uint8_t> bytes) {
     viewport_  = new_view;
     snapshots_ = new_bank;
     patterns_  = std::move(new_patterns);
-    if (new_layout != layout_) set_layout(new_layout);
+    // Sync layout_ from the deserialized JSON without going through
+    // set_layout() — that path writes the quantized index back to
+    // kBandCount, which would clobber the raw float just loaded by the
+    // CLAP/VST3/AU param-map restore. Both halves of state must stay
+    // byte-equal across save→load round-trips for clap-validator's
+    // state-reproducibility-* checks.
+    if (new_layout != layout_) {
+        layout_ = new_layout;
+        rebuild_engine_();
+    }
     return true;
 }
 


### PR DESCRIPTION
## Summary

Closes M10 (CLAP format validation).

- Bump Spectr's pulp SDK pin from 0.42.0 → 0.47.0 in CMakeLists.txt + .shipyard/config.toml + pulp.toml.
  Picks up pulp #748 (CLAP MIDI dialect) and #760 (gzip web-compat assets), which clears 2 of 3 prior clap-validator failures.
- Fix the remaining `state-reproducibility-flush` failure on the 'Bands' param.
  The discrete-quantization writeback in `Spectr::set_layout()` was running on host-driven sync paths
  (process + deserialize) but not on `clap_plugin_params::flush()`, making the StateStore-side
  raw float diverge between A (process) and B (flush). Fix: in process() and deserialize_plugin_state()
  just update the cached `layout_` + `rebuild_engine_()` directly without round-tripping through
  set_layout(). Direct UI/test calls to set_layout() still writeback (test_m4_state.cpp:77 depends
  on this for the serialize-from-cache path).

## Validation

- `clap-validator validate ~/Library/Audio/Plug-Ins/CLAP/Spectr.clap`:
  20 tests run, **15 passed, 0 failed**, 5 skipped (instrument-only ports tests that don't apply
  to an effect), 1 warning (341ms scan time — perf-only).
- `ctest --test-dir build`: **109/109** green.

## Test plan

- [x] M4 + preset tests pass (regression check on the writeback-removal path)
- [x] Full suite green
- [x] clap-validator clean
- [ ] CI green on macOS (shipyard ship)